### PR TITLE
feat(#5): swagger 및 공통 에러 응답 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.5.5'
+	id 'org.springframework.boot' version '3.2.5'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -32,6 +32,9 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	//swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/org/quizly/quizly/configuration/swagger/ApiErrorCode.java
+++ b/src/main/java/org/quizly/quizly/configuration/swagger/ApiErrorCode.java
@@ -1,0 +1,15 @@
+package org.quizly.quizly.configuration.swagger;
+
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.quizly.quizly.core.exception.error.BaseErrorCode;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ApiErrorCode {
+
+  Class<? extends BaseErrorCode>[] errorCodes();
+}

--- a/src/main/java/org/quizly/quizly/configuration/swagger/SwaggerConfiguration.java
+++ b/src/main/java/org/quizly/quizly/configuration/swagger/SwaggerConfiguration.java
@@ -1,0 +1,85 @@
+package org.quizly.quizly.configuration.swagger;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.examples.Example;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.quizly.quizly.core.exception.error.BaseErrorCode;
+import org.quizly.quizly.core.presentation.ErrorResponse;
+import org.springdoc.core.customizers.OperationCustomizer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConditionalOnProperty(name = "swagger.enabled")
+public class SwaggerConfiguration {
+
+  public static final String SECURITY_SCHEME_NAME = "BearerToken";
+
+  @Bean
+  public OpenAPI customOpenAPI(@Value("${springdoc.version}") String appVersion, @Value("${server.name}") String serverName) {
+    return new OpenAPI()
+        .components(new Components().addSecuritySchemes(SECURITY_SCHEME_NAME, securityScheme()))
+        .info(new Info().title(serverName).version(appVersion));
+  }
+
+  @Bean
+  public OperationCustomizer operationCustomizer() {
+    return (operation, handlerMethod) -> {
+      ApiErrorCode apiErrorCode = handlerMethod.getMethodAnnotation(ApiErrorCode.class);
+      if (apiErrorCode != null) {
+        generateErrorResponseDocs(operation, apiErrorCode.errorCodes());
+      }
+      return operation;
+    };
+  }
+
+  private void generateErrorResponseDocs(Operation operation, Class<? extends BaseErrorCode>[] errorCodes) {
+    ApiResponses responses = operation.getResponses();
+
+    Map<Integer, List<BaseErrorCode>> statusAndErrorCodes = groupErrorCodesByStatus(errorCodes);
+
+    statusAndErrorCodes.forEach((status, codeList) -> {
+      ApiResponse apiResponse = createErrorApiResponse(codeList);
+      responses.addApiResponse(String.valueOf(status), apiResponse);
+    });
+  }
+
+  private Map<Integer, List<BaseErrorCode>> groupErrorCodesByStatus(Class<? extends BaseErrorCode>[] errorCodes) {
+    return Arrays.stream(errorCodes)
+        .flatMap(enumClass -> Arrays.stream(enumClass.getEnumConstants()))
+        .collect(Collectors.groupingBy(baseErrorCode -> baseErrorCode.getHttpStatus().value()));
+  }
+
+  private ApiResponse createErrorApiResponse(List<BaseErrorCode> codeList) {
+    MediaType mediaType = new MediaType();
+    codeList.forEach(baseErrorCode -> {
+      ErrorResponse errorResponse = ErrorResponse.of(baseErrorCode);
+      Example example = new Example().value(errorResponse);
+      mediaType.addExamples(baseErrorCode.name(), example);
+    });
+
+    Content content = new Content().addMediaType("application/json", mediaType);
+    return new ApiResponse().description("Error Response").content(content);
+  }
+
+  private SecurityScheme securityScheme() {
+    return new SecurityScheme()
+        .type(SecurityScheme.Type.HTTP)
+        .scheme("bearer")
+        .bearerFormat("KMS")
+        .name(SECURITY_SCHEME_NAME);
+  }
+}

--- a/src/main/java/org/quizly/quizly/core/exception/SystemExceptionHandler.java
+++ b/src/main/java/org/quizly/quizly/core/exception/SystemExceptionHandler.java
@@ -1,0 +1,19 @@
+package org.quizly.quizly.core.exception;
+
+import org.quizly.quizly.core.presentation.ErrorResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestControllerAdvice
+public class SystemExceptionHandler {
+
+  @ExceptionHandler(Exception.class)
+  public ResponseEntity<ErrorResponse> handleException(Exception e) {
+    log.error("[SystemExceptionHandler] handleException", e);
+    return ResponseEntity.internalServerError()
+        .body(ErrorResponse.of(500, e));
+  }
+}

--- a/src/main/java/org/quizly/quizly/core/exception/error/BaseErrorCode.java
+++ b/src/main/java/org/quizly/quizly/core/exception/error/BaseErrorCode.java
@@ -1,0 +1,14 @@
+package org.quizly.quizly.core.exception.error;
+
+import org.springframework.http.HttpStatus;
+
+public interface BaseErrorCode<T extends RuntimeException> {
+
+  String name();
+
+  String getMessage();
+
+  HttpStatus getHttpStatus();
+
+  T toException();
+}

--- a/src/main/java/org/quizly/quizly/core/exception/error/GlobalErrorCode.java
+++ b/src/main/java/org/quizly/quizly/core/exception/error/GlobalErrorCode.java
@@ -1,0 +1,21 @@
+package org.quizly.quizly.core.exception.error;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum GlobalErrorCode implements BaseErrorCode<RuntimeException> {
+
+  INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "알 수 없는 내부 오류입니다.");
+
+  private final HttpStatus httpStatus;
+
+  private final String message;
+
+  @Override
+  public RuntimeException toException() {
+    return new RuntimeException(message);
+  }
+}

--- a/src/main/java/org/quizly/quizly/core/presentation/ErrorResponse.java
+++ b/src/main/java/org/quizly/quizly/core/presentation/ErrorResponse.java
@@ -1,0 +1,51 @@
+package org.quizly.quizly.core.presentation;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.time.ZonedDateTime;
+import lombok.Builder;
+import lombok.Getter;
+import org.quizly.quizly.core.exception.error.BaseErrorCode;
+import org.quizly.quizly.core.util.TimeUtil;
+
+@Getter
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ErrorResponse {
+
+  private final int statusCode;
+
+  private final String timeStamp;
+
+  private final boolean ok = false;
+
+  private final Error error;
+
+  private final String code;
+
+  @Getter
+  @Builder
+  public static class Error {
+
+    private final String message;
+  }
+
+
+  public static ErrorResponse of(int statusCode, Exception exception) {
+    return ErrorResponse.builder()
+        .statusCode(statusCode)
+        .timeStamp(TimeUtil.toString(ZonedDateTime.now()))
+        .code(exception.getClass().getSimpleName())
+        .error(Error.builder().message(exception.getMessage()).build())
+        .build();
+  }
+
+  public static ErrorResponse of(BaseErrorCode baseErrorCode) {
+    return ErrorResponse.builder()
+        .statusCode(baseErrorCode.getHttpStatus().value())
+        .timeStamp(TimeUtil.toString(ZonedDateTime.now()))
+        .code(baseErrorCode.name())
+        .error(Error.builder().message(baseErrorCode.getMessage()).build())
+        .build();
+  }
+}
+

--- a/src/main/java/org/quizly/quizly/core/util/TimeUtil.java
+++ b/src/main/java/org/quizly/quizly/core/util/TimeUtil.java
@@ -1,0 +1,37 @@
+package org.quizly.quizly.core.util;
+
+import java.time.DateTimeException;
+import java.time.LocalTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class TimeUtil {
+
+  private static final DateTimeFormatter HH_MM_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
+
+  public static String toString(ZonedDateTime zonedDateTime) {
+    if (zonedDateTime == null) {
+      return null;
+    }
+    try {
+      return zonedDateTime.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+    } catch (DateTimeException e) {
+      return null;
+    }
+  }
+
+  public static String toString(LocalTime time) {
+    if (time == null) {
+      return null;
+    }
+    try {
+      return time.format(HH_MM_FORMATTER);
+    } catch (DateTimeException e) {
+      return null;
+    }
+  }
+}


### PR DESCRIPTION
- 연관 이슈
이 PR이 해결하는 이슈: Closes #5   (병합 시 자동으로 이슈 닫힘)

- 작업 사항
1. 공통 에러 응답 설정
2. OperationCustomizer 사용하여 swagger 문서에서도 제작한 공통 에러 응답 반환하도록 설정

- 테스트
<img width="2116" height="1938" alt="image" src="https://github.com/user-attachments/assets/a1c816d6-765b-470e-865a-f0f2fa42bd13" />


- 주의점
build.gradle에서 스프링 버전의 변경점 존재 (springdoc와 충돌로 인한 수정)