### PR TITLE
feat(#9): naver 소셜 로그인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,14 @@ dependencies {
 
 	// external API + json
 	implementation 'com.squareup.okhttp3:okhttp:4.12.0'
+
+	// OAuth2 + security + jwt
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	testImplementation 'org.springframework.security:spring-security-test'
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 	
 }
 

--- a/src/main/java/org/quizly/quizly/configuration/CorsMvcConfig.java
+++ b/src/main/java/org/quizly/quizly/configuration/CorsMvcConfig.java
@@ -1,0 +1,26 @@
+package org.quizly.quizly.configuration;
+
+import java.util.List;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+@Configuration
+public class CorsMvcConfig {
+
+  @Bean
+  public CorsConfigurationSource corsConfigurationSource() {
+    CorsConfiguration configuration = new CorsConfiguration();
+    configuration.setAllowedOrigins(List.of("http://localhost:3000"));
+    configuration.setAllowedMethods(List.of("*"));
+    configuration.setAllowedHeaders(List.of("*"));
+    configuration.setAllowCredentials(true);
+    configuration.setMaxAge(3600L);
+
+    UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+    source.registerCorsConfiguration("/**", configuration);
+    return source;
+  }
+}

--- a/src/main/java/org/quizly/quizly/configuration/SecurityConfig.java
+++ b/src/main/java/org/quizly/quizly/configuration/SecurityConfig.java
@@ -1,0 +1,66 @@
+package org.quizly.quizly.configuration;
+
+import lombok.RequiredArgsConstructor;
+import org.quizly.quizly.jwt.JwtAuthenticationFilter;
+import org.quizly.quizly.jwt.error.JwtAuthenticationEntryPoint;
+import org.quizly.quizly.oauth.service.OAuth2LoginUserService;
+import org.quizly.quizly.oauth.OAuth2LoginSuccessHandler;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfigurationSource;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+  private final OAuth2LoginUserService oAuth2LoginUserService;
+  private final OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
+  private final JwtAuthenticationFilter jwtAuthenticationFilter;
+  private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+  private final CorsConfigurationSource corsConfigurationSource;
+
+  @Bean
+  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+
+    http.cors(cors -> cors.configurationSource(corsConfigurationSource))
+
+        .csrf(AbstractHttpConfigurer::disable)
+        .formLogin(AbstractHttpConfigurer::disable)
+        .httpBasic(AbstractHttpConfigurer::disable)
+
+        .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+
+        .oauth2Login(oauth2 -> oauth2
+            .userInfoEndpoint(userInfoEndpointConfig -> userInfoEndpointConfig
+                .userService(oAuth2LoginUserService))
+            .successHandler(oAuth2LoginSuccessHandler)
+        )
+
+        .exceptionHandling(exception -> exception
+            .authenticationEntryPoint(jwtAuthenticationEntryPoint))
+
+        .sessionManagement(session -> session
+            .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+
+        .authorizeHttpRequests(auth -> auth
+            .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+            .requestMatchers(
+                "/",
+                "/docs",
+                "/swagger-ui/**",
+                "/api-docs/**",
+                "/auth/reissue"
+            ).permitAll()
+            .anyRequest().authenticated());
+
+    return http.build();
+  }
+}

--- a/src/main/java/org/quizly/quizly/configuration/swagger/SwaggerConfiguration.java
+++ b/src/main/java/org/quizly/quizly/configuration/swagger/SwaggerConfiguration.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.models.media.Content;
 import io.swagger.v3.oas.models.media.MediaType;
 import io.swagger.v3.oas.models.responses.ApiResponse;
 import io.swagger.v3.oas.models.responses.ApiResponses;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import java.util.Arrays;
 import java.util.List;
@@ -26,13 +27,21 @@ import org.springframework.context.annotation.Configuration;
 @ConditionalOnProperty(name = "swagger.enabled")
 public class SwaggerConfiguration {
 
-  public static final String SECURITY_SCHEME_NAME = "BearerToken";
-
   @Bean
   public OpenAPI customOpenAPI(@Value("${springdoc.version}") String appVersion, @Value("${server.name}") String serverName) {
+    SecurityScheme securityScheme = new SecurityScheme()
+        .type(SecurityScheme.Type.HTTP)
+        .scheme("bearer")
+        .bearerFormat("JWT")
+        .in(SecurityScheme.In.HEADER)
+        .name("Authorization");
+
+    SecurityRequirement securityRequirement = new SecurityRequirement().addList("BearerToken");
+
     return new OpenAPI()
-        .components(new Components().addSecuritySchemes(SECURITY_SCHEME_NAME, securityScheme()))
-        .info(new Info().title(serverName).version(appVersion));
+        .info(new Info().title(serverName).version(appVersion))
+        .addSecurityItem(securityRequirement)
+        .components(new Components().addSecuritySchemes("BearerToken", securityScheme));
   }
 
   @Bean
@@ -73,13 +82,5 @@ public class SwaggerConfiguration {
 
     Content content = new Content().addMediaType("application/json", mediaType);
     return new ApiResponse().description("Error Response").content(content);
-  }
-
-  private SecurityScheme securityScheme() {
-    return new SecurityScheme()
-        .type(SecurityScheme.Type.HTTP)
-        .scheme("bearer")
-        .bearerFormat("KMS")
-        .name(SECURITY_SCHEME_NAME);
   }
 }

--- a/src/main/java/org/quizly/quizly/core/domin/entity/RefreshToken.java
+++ b/src/main/java/org/quizly/quizly/core/domin/entity/RefreshToken.java
@@ -1,0 +1,31 @@
+package org.quizly.quizly.core.domin.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+import org.quizly.quizly.core.domin.shared.BaseEntity;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@SuperBuilder
+@Entity
+@Table(name = "refresh_token")
+public class RefreshToken extends BaseEntity {
+
+  @Column(nullable = false, unique = true)
+  private String providerId;
+
+  @Column(nullable = false)
+  private String name;
+
+  @Column(nullable = false)
+  private String token;
+
+}

--- a/src/main/java/org/quizly/quizly/core/domin/entity/User.java
+++ b/src/main/java/org/quizly/quizly/core/domin/entity/User.java
@@ -3,6 +3,8 @@ package org.quizly.quizly.core.domin.entity;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -13,6 +15,7 @@ import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 import org.quizly.quizly.core.domin.shared.BaseEntity;
@@ -26,18 +29,46 @@ import org.quizly.quizly.core.domin.shared.BaseEntity;
 @Table(name = "user")
 public class User extends BaseEntity {
 
-  @Column(
-      nullable = false,
-      unique = true,
-      columnDefinition = "varchar(255) collate utf8mb4_bin"
-  )
-  private String loginId;
+  public enum Provider {
+    NAVER,
+    GOOGLE,
+    KAKAO
+  }
+
+  @Getter
+  @RequiredArgsConstructor
+  public enum Role {
+    USER("ROLE_USER"),
+    ADMIN("ROLE_ADMIN");
+
+    private final String key;
+
+    public static Role fromKey(String key) {
+      for (Role role : Role.values()) {
+        if (role.getKey().equals(key)) {
+          return role;
+        }
+      }
+      throw new IllegalArgumentException("Invalid role key: " + key);
+    }
+  }
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = true)
+  private Provider provider;
+
+  @Column(nullable = true, unique = true)
+  private String providerId;
 
   @Column(nullable = false)
-  private String password;
+  private String name;
 
   @Column(nullable = false)
-  private String nickname;
+  private String email;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private Role role;
 
   @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
   private List<Quiz> quizList = new ArrayList<>();

--- a/src/main/java/org/quizly/quizly/core/domin/repository/RefreshTokenRepository.java
+++ b/src/main/java/org/quizly/quizly/core/domin/repository/RefreshTokenRepository.java
@@ -1,0 +1,9 @@
+package org.quizly.quizly.core.domin.repository;
+
+import org.quizly.quizly.core.domin.entity.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+
+  RefreshToken findByProviderId(String providerId);
+}

--- a/src/main/java/org/quizly/quizly/core/domin/repository/UserRepository.java
+++ b/src/main/java/org/quizly/quizly/core/domin/repository/UserRepository.java
@@ -1,0 +1,9 @@
+package org.quizly.quizly.core.domin.repository;
+
+import org.quizly.quizly.core.domin.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+  User findByProviderId(String providerId);
+}

--- a/src/main/java/org/quizly/quizly/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/org/quizly/quizly/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,61 @@
+package org.quizly.quizly.jwt;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.quizly.quizly.jwt.error.AuthErrorCode;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+  private final JwtProvider jwtProvider;
+
+  @Override
+  protected void doFilterInternal(
+      HttpServletRequest request,
+      HttpServletResponse response,
+      FilterChain filterChain) throws ServletException, IOException {
+
+    String token = resolveToken(request);
+
+    if (StringUtils.hasText(token)) {
+      AuthErrorCode errorCode = jwtProvider.validateToken(token);
+      if (errorCode == null) {
+        Authentication authentication = jwtProvider.getAuthentication(token);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+      } else {
+        request.setAttribute("exception", errorCode);
+        if (errorCode == AuthErrorCode.EXPIRED_ACCESS_TOKEN) {
+          log.warn("Expired JWT token: {}", token);
+        } else {
+          log.error("Invalid JWT token: {}", token);
+        }
+      }
+    } else {
+      request.setAttribute("exception", AuthErrorCode.TOKEN_NOT_FOUND);
+    }
+
+    filterChain.doFilter(request, response);
+  }
+
+  private String resolveToken(HttpServletRequest request) {
+    String bearerToken = request.getHeader("Authorization");
+    if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+      return bearerToken.substring(7);
+    }
+    return null;
+  }
+}

--- a/src/main/java/org/quizly/quizly/jwt/JwtProvider.java
+++ b/src/main/java/org/quizly/quizly/jwt/JwtProvider.java
@@ -1,0 +1,88 @@
+package org.quizly.quizly.jwt;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import jakarta.annotation.PostConstruct;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import lombok.RequiredArgsConstructor;
+import org.quizly.quizly.core.domin.entity.User.Role;
+import org.quizly.quizly.jwt.error.AuthErrorCode;
+import org.quizly.quizly.oauth.UserPrincipal;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class JwtProvider {
+
+  @Value("${jwt.secret}")
+  private String secret;
+
+  private SecretKey secretKey;
+
+  @Value("${jwt.access-token-expiration}")
+  private  Long accessTokenExpiration;
+
+  @Value("${jwt.refresh-token-expiration}")
+  private Long refreshTokenExpiration;
+
+  @PostConstruct
+  private void init() {
+    this.secretKey = io.jsonwebtoken.security.Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+  }
+
+  public String getProviderId(String token) {
+    return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload()
+        .get("providerId", String.class);
+  }
+
+  public String getRole(String token) {
+    return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload()
+        .get("role", String.class);
+  }
+
+  public AuthErrorCode validateToken(String token) {
+    try {
+      Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token);
+      return null;
+    } catch (ExpiredJwtException e) {
+      return AuthErrorCode.EXPIRED_ACCESS_TOKEN;
+    } catch (JwtException | IllegalArgumentException e) {
+      return AuthErrorCode.INVALID_TOKEN;
+    }
+  }
+
+  public String generateAccessToken(String providerId, String role) {
+    return Jwts.builder()
+        .claim("providerId", providerId)
+        .claim("role", role)
+        .issuedAt(new Date(System.currentTimeMillis()))
+        .expiration(new Date(System.currentTimeMillis() + accessTokenExpiration))
+        .signWith(secretKey)
+        .compact();
+  }
+
+  public String generateRefreshToken(String providerId) {
+    return Jwts.builder()
+        .claim("providerId", providerId)
+        .issuedAt(new Date(System.currentTimeMillis()))
+        .expiration(new Date(System.currentTimeMillis() + refreshTokenExpiration))
+        .signWith(secretKey)
+        .compact();
+  }
+
+  public Authentication getAuthentication(String token) {
+    String providerId = getProviderId(token);
+    String roleString = getRole(token);
+    Role role = Role.fromKey(roleString);
+
+    UserPrincipal userPrincipal = new UserPrincipal(providerId, role);
+    return new UsernamePasswordAuthenticationToken(userPrincipal, null, userPrincipal.getAuthorities());
+  }
+}

--- a/src/main/java/org/quizly/quizly/jwt/error/AuthErrorCode.java
+++ b/src/main/java/org/quizly/quizly/jwt/error/AuthErrorCode.java
@@ -1,0 +1,24 @@
+package org.quizly.quizly.jwt.error;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.quizly.quizly.core.exception.DomainException;
+import org.quizly.quizly.core.exception.error.BaseErrorCode;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum AuthErrorCode implements BaseErrorCode<DomainException> {
+
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
+    EXPIRED_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "액세스 토큰이 만료되었습니다."),
+    TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "토큰이 존재하지 않습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    @Override
+    public DomainException toException() {
+        return new DomainException(httpStatus, this);
+    }
+}

--- a/src/main/java/org/quizly/quizly/jwt/error/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/org/quizly/quizly/jwt/error/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,34 @@
+package org.quizly.quizly.jwt.error;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.quizly.quizly.core.presentation.ErrorResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+        AuthenticationException authException) throws IOException {
+        AuthErrorCode errorCode = (AuthErrorCode) request.getAttribute("exception");
+
+        if (errorCode == null) {
+            errorCode = AuthErrorCode.INVALID_TOKEN; 
+        }
+
+        response.setStatus(errorCode.getHttpStatus().value());
+        response.setContentType("application/json;charset=UTF-8");
+
+        ErrorResponse errorResponse = ErrorResponse.of(errorCode);
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+    }
+}

--- a/src/main/java/org/quizly/quizly/oauth/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/org/quizly/quizly/oauth/OAuth2LoginSuccessHandler.java
@@ -1,0 +1,75 @@
+package org.quizly.quizly.oauth;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.quizly.quizly.core.domin.entity.RefreshToken;
+import org.quizly.quizly.core.domin.repository.RefreshTokenRepository;
+import org.quizly.quizly.jwt.JwtProvider;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+//  TODO: 프로덕션 환경에서는 secure 플래그를 true로 설정해야 합니다. (하단 주석 코드)
+@RequiredArgsConstructor
+@Component
+public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
+
+  private final JwtProvider jwtProvider;
+  private final RefreshTokenRepository refreshTokenRepository;
+  private final ObjectMapper objectMapper;
+
+  @Value("${jwt.refresh-token-expiration}")
+  private Long refreshTokenExpiration;
+
+
+  @Override
+  @Transactional
+  public void onAuthenticationSuccess(
+      HttpServletRequest request,
+      HttpServletResponse response,
+      Authentication authentication) throws IOException, ServletException {
+
+    UserPrincipal customUserDetails = (UserPrincipal) authentication.getPrincipal();
+
+    String providerId = customUserDetails.getProviderId();
+
+    String role = authentication.getAuthorities().stream()
+        .findFirst()
+        .map(GrantedAuthority::getAuthority)
+        .orElseThrow(() -> new IllegalStateException("User has no authorities"));
+
+    String accessToken = jwtProvider.generateAccessToken(providerId, role);
+    String refreshToken = jwtProvider.generateRefreshToken(providerId);
+
+    RefreshToken refreshTokenEntity = refreshTokenRepository.findByProviderId(providerId);
+    if (refreshTokenEntity != null) {
+      refreshTokenEntity.setToken(refreshToken);
+    } else {
+      refreshTokenRepository.save(new RefreshToken(providerId, customUserDetails.getName(), refreshToken));
+    }
+
+    Cookie refreshTokenCookie = new Cookie("refreshToken", refreshToken);
+    refreshTokenCookie.setHttpOnly(true);
+    refreshTokenCookie.setPath("/");
+    refreshTokenCookie.setMaxAge((int) (refreshTokenExpiration / 1000));
+    // refreshTokenCookie.setSecure(true);
+
+    Map<String, String> tokenMap = new HashMap<>();
+    tokenMap.put("accessToken", accessToken);
+
+    response.addCookie(refreshTokenCookie);
+    response.setContentType("application/json");
+    response.setCharacterEncoding("UTF-8");
+    response.getWriter().write(objectMapper.writeValueAsString(tokenMap));
+  }
+}

--- a/src/main/java/org/quizly/quizly/oauth/UserPrincipal.java
+++ b/src/main/java/org/quizly/quizly/oauth/UserPrincipal.java
@@ -1,0 +1,58 @@
+package org.quizly.quizly.oauth;
+
+import jakarta.persistence.Column;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.quizly.quizly.core.domin.entity.User;
+import org.quizly.quizly.core.domin.entity.User.Provider;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+@Getter
+public class UserPrincipal implements OAuth2User {
+
+  private final Provider provider;
+  private final String providerId;
+  private final String name;
+  private final User.Role role;
+
+  public UserPrincipal(Provider provider, String providerId, String name, User.Role role) {
+    this.provider = provider;
+    this.providerId = providerId;
+    this.name = name;
+    this.role = role;
+  }
+
+  public UserPrincipal(String providerId, User.Role role) {
+    this.provider = null;
+    this.providerId = providerId;
+    this.name = null;
+    this.role = role;
+  }
+
+  @Override
+  public Map<String, Object> getAttributes() {
+    return null;
+  }
+
+  @Override
+  public Collection<? extends GrantedAuthority> getAuthorities() {
+    Collection<GrantedAuthority> collection = new ArrayList<>();
+    collection.add(new GrantedAuthority() {
+      @Override
+      public String getAuthority() {
+        return role.getKey();
+      }
+    });
+    return collection;
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+}

--- a/src/main/java/org/quizly/quizly/oauth/controller/AccessTokenReissueController.java
+++ b/src/main/java/org/quizly/quizly/oauth/controller/AccessTokenReissueController.java
@@ -1,0 +1,62 @@
+package org.quizly.quizly.oauth.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.quizly.quizly.configuration.swagger.ApiErrorCode;
+import org.quizly.quizly.core.application.BaseResponse;
+import org.quizly.quizly.core.exception.error.GlobalErrorCode;
+import org.quizly.quizly.oauth.dto.response.AccessTokenReissueResponse;
+import org.quizly.quizly.oauth.service.AccessTokenReissueService;
+import org.quizly.quizly.oauth.service.AccessTokenReissueService.AccessTokenReissueErrorCode;
+import org.quizly.quizly.oauth.service.AccessTokenReissueService.AccessTokenReissueRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "auth", description = "인증")
+public class AccessTokenReissueController {
+
+  private final AccessTokenReissueService accessTokenReissueService;
+
+  @Operation(
+      summary = "accessToken 재발급 API",
+      description = "유효한 refreshToken으로 accessToken를 재발급합니다.\n\n해당 API는 로그인 시 발급된 refreshToken 쿠키를 자동으로 사용하여 작동합니다.",
+      operationId = "/auth/reissue"
+  )
+  @PostMapping("/auth/reissue")
+  @ApiErrorCode(errorCodes = {GlobalErrorCode.class, AccessTokenReissueErrorCode.class})
+  public ResponseEntity<AccessTokenReissueResponse> refreshAccessToken(@CookieValue("refreshToken") @Parameter(hidden = true) String refreshToken, HttpServletResponse response) {
+
+    AccessTokenReissueRequest accessTokenReissueRequest = AccessTokenReissueRequest.builder()
+        .refreshToken(refreshToken)
+        .build();
+
+    AccessTokenReissueService.AccessTokenReissueResponse serviceResponse = accessTokenReissueService.execute(accessTokenReissueRequest);
+
+    if (!serviceResponse.isSuccess()) {
+      Optional.of(serviceResponse)
+          .map(BaseResponse::getErrorCode)
+          .ifPresent(errorCode -> {
+            throw errorCode.toException();
+          });
+    }
+
+    Cookie newRefreshTokenCookie = new Cookie("refreshToken", serviceResponse.getRefreshToken());
+    newRefreshTokenCookie.setHttpOnly(true);
+    newRefreshTokenCookie.setPath("/");
+    response.addCookie(newRefreshTokenCookie);
+
+    return ResponseEntity.ok(
+        AccessTokenReissueResponse.builder()
+            .accessToken(serviceResponse.getAccessToken())
+            .build());
+  }
+}

--- a/src/main/java/org/quizly/quizly/oauth/dto/response/AccessTokenReissueResponse.java
+++ b/src/main/java/org/quizly/quizly/oauth/dto/response/AccessTokenReissueResponse.java
@@ -1,0 +1,24 @@
+package org.quizly.quizly.oauth.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+import org.quizly.quizly.core.application.BaseResponse;
+import org.quizly.quizly.core.exception.error.GlobalErrorCode;
+
+@Getter
+@Setter
+@SuperBuilder
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+@Schema(description = "액세스 토큰 재발급 응답")
+public class AccessTokenReissueResponse extends BaseResponse<GlobalErrorCode> {
+
+  @Schema(description = "새로 발급된 액세스 토큰", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
+  private String accessToken;
+}

--- a/src/main/java/org/quizly/quizly/oauth/dto/response/NaverUserInfo.java
+++ b/src/main/java/org/quizly/quizly/oauth/dto/response/NaverUserInfo.java
@@ -1,0 +1,48 @@
+package org.quizly.quizly.oauth.dto.response;
+
+import java.util.Map;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
+
+public class NaverUserInfo implements OAuth2UserInfo {
+
+  private final Map<String, Object> attribute;
+
+  public NaverUserInfo(Map<String, Object> attribute) {
+    Object response = attribute.get("response");
+    if (!(response instanceof Map)) {
+      throw new OAuth2AuthenticationException(new OAuth2Error("invalid_response",
+          "Invalid Naver API response: 'response' field is missing or not a Map.", null));
+    }
+    this.attribute = (Map<String, Object>) response;
+  }
+
+  private String getAttribute(String key) {
+    Object value = this.attribute.get(key);
+    if (value == null) {
+      throw new OAuth2AuthenticationException(new OAuth2Error("invalid_response",
+          "Missing required field in Naver API response: " + key, null));
+    }
+    return value.toString();
+  }
+
+  @Override
+  public String getProvider() {
+    return "naver";
+  }
+
+  @Override
+  public String getProviderId() {
+    return getAttribute("id");
+  }
+
+  @Override
+  public String getEmail() {
+    return getAttribute("email");
+  }
+
+  @Override
+  public String getName() {
+    return getAttribute("name");
+  }
+}

--- a/src/main/java/org/quizly/quizly/oauth/dto/response/OAuth2UserInfo.java
+++ b/src/main/java/org/quizly/quizly/oauth/dto/response/OAuth2UserInfo.java
@@ -1,0 +1,12 @@
+package org.quizly.quizly.oauth.dto.response;
+
+public interface OAuth2UserInfo {
+
+  String getProvider();
+
+  String getProviderId();
+
+  String getEmail();
+
+  String getName();
+}

--- a/src/main/java/org/quizly/quizly/oauth/service/AccessTokenReissueService.java
+++ b/src/main/java/org/quizly/quizly/oauth/service/AccessTokenReissueService.java
@@ -1,0 +1,141 @@
+package org.quizly.quizly.oauth.service;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+import lombok.extern.slf4j.Slf4j;
+import org.quizly.quizly.core.application.BaseRequest;
+import org.quizly.quizly.core.application.BaseResponse;
+import org.quizly.quizly.core.application.BaseService;
+import org.quizly.quizly.core.domin.entity.RefreshToken;
+import org.quizly.quizly.core.domin.entity.User;
+import org.quizly.quizly.core.domin.entity.User.Role;
+import org.quizly.quizly.core.domin.repository.RefreshTokenRepository;
+import org.quizly.quizly.core.domin.repository.UserRepository;
+import org.quizly.quizly.core.exception.DomainException;
+import org.quizly.quizly.core.exception.error.BaseErrorCode;
+import org.quizly.quizly.jwt.JwtProvider;
+import org.quizly.quizly.jwt.error.AuthErrorCode;
+import org.quizly.quizly.oauth.service.AccessTokenReissueService.AccessTokenReissueRequest;
+import org.quizly.quizly.oauth.service.AccessTokenReissueService.AccessTokenReissueResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class AccessTokenReissueService implements BaseService<AccessTokenReissueRequest, AccessTokenReissueResponse> {
+
+    private final JwtProvider jwtProvider;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final UserRepository userRepository;
+
+    @Override
+    public AccessTokenReissueResponse execute(AccessTokenReissueRequest accessTokenReissueRequest) {
+        String refreshToken = accessTokenReissueRequest.getRefreshToken();
+
+        AuthErrorCode errorCode = jwtProvider.validateToken(refreshToken);
+
+        if (errorCode != null) {
+            if (errorCode == AuthErrorCode.EXPIRED_ACCESS_TOKEN) {
+                return AccessTokenReissueResponse.builder()
+                    .success(false)
+                    .errorCode(AccessTokenReissueErrorCode.REFRESH_TOKEN_EXPIRED)
+                    .build();
+            } else {
+                return AccessTokenReissueResponse.builder()
+                    .success(false)
+                    .errorCode(AccessTokenReissueErrorCode.REFRESH_TOKEN_INVALID)
+                    .build();
+            }
+        }
+
+        String providerId = jwtProvider.getProviderId(refreshToken);
+
+        User user = userRepository.findByProviderId(providerId);
+        if (user == null) {
+            log.warn("User not found for providerId derived from a refresh token. ProviderId: {}", providerId);
+            return AccessTokenReissueResponse.builder()
+                .success(false)
+                .errorCode(AccessTokenReissueErrorCode.USER_NOT_FOUND)
+                .build();
+        }
+
+        String role = user.getRole().getKey();
+
+        RefreshToken refreshTokenEntity = refreshTokenRepository.findByProviderId(providerId);
+
+        if (refreshTokenEntity == null) {
+            return AccessTokenReissueResponse.builder()
+                .success(false)
+                .errorCode(AccessTokenReissueErrorCode.REFRESH_TOKEN_NOT_FOUND)
+                .build();
+        }
+        if (!refreshTokenEntity.getToken().equals(refreshToken)) {
+            log.warn("Refresh Token Mismatch Detected. ProviderId: {}", providerId);
+            return AccessTokenReissueResponse.builder()
+                .success(false)
+                .errorCode(AccessTokenReissueErrorCode.REFRESH_TOKEN_INVALID)
+                .build();
+        }
+        String newAccessToken = jwtProvider.generateAccessToken(providerId, role);
+        String newRefreshToken = jwtProvider.generateRefreshToken(providerId);
+
+        refreshTokenEntity.setToken(newRefreshToken);
+
+        return AccessTokenReissueResponse.builder()
+            .accessToken(newAccessToken)
+            .refreshToken(newRefreshToken)
+            .build();
+    }
+
+    @Getter
+    @RequiredArgsConstructor
+    public enum AccessTokenReissueErrorCode implements BaseErrorCode<DomainException> {
+        REFRESH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "리프레시 토큰이 만료되었습니다."),
+        REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "리프레시 토큰을 찾을 수 없습니다."),
+        USER_NOT_FOUND(HttpStatus.NOT_FOUND, "토큰에 해당하는 사용자를 찾을 수 없습니다."),
+        REFRESH_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "유효하지 않은 리프레시 토큰입니다.");
+
+        private final HttpStatus httpStatus;
+        private final String message;
+
+        @Override
+        public DomainException toException() {
+            return new DomainException(httpStatus, this);
+        }
+    }
+
+    @Getter
+    @Setter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @ToString
+    public static class AccessTokenReissueRequest implements BaseRequest {
+        private String refreshToken;
+
+        @Override
+        public boolean isValid() {
+            return refreshToken != null && !refreshToken.isEmpty();
+        }
+    }
+
+    @Getter
+    @Setter
+    @SuperBuilder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @ToString
+    public static class AccessTokenReissueResponse extends BaseResponse<AccessTokenReissueErrorCode> {
+        private String accessToken;
+        private String refreshToken;
+    }
+}

--- a/src/main/java/org/quizly/quizly/oauth/service/OAuth2LoginUserService.java
+++ b/src/main/java/org/quizly/quizly/oauth/service/OAuth2LoginUserService.java
@@ -1,0 +1,83 @@
+package org.quizly.quizly.oauth.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.quizly.quizly.core.domin.entity.User;
+import org.quizly.quizly.core.domin.entity.User.Provider;
+import org.quizly.quizly.core.domin.entity.User.Role;
+import org.quizly.quizly.core.domin.repository.UserRepository;
+import org.quizly.quizly.oauth.UserPrincipal;
+import org.quizly.quizly.oauth.dto.response.NaverUserInfo;
+import org.quizly.quizly.oauth.dto.response.OAuth2UserInfo;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class OAuth2LoginUserService extends DefaultOAuth2UserService {
+
+  private final UserRepository userRepository;
+
+  @Override
+  public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+
+    OAuth2User oAuth2User = super.loadUser(userRequest);
+    log.info("oAuth2User: {}", oAuth2User);
+
+    String registrationId = userRequest.getClientRegistration().getRegistrationId();
+    OAuth2UserInfo oAuth2UserInfo = getOAuth2UserInfo(registrationId, oAuth2User);
+    if (oAuth2UserInfo == null) {
+      return null;
+    }
+
+    User user = processUser(oAuth2UserInfo);
+
+    return new UserPrincipal(user.getProvider(), user.getProviderId(), user.getName(), user.getRole());
+  }
+
+  private OAuth2UserInfo getOAuth2UserInfo(String registrationId, OAuth2User oAuth2User) {
+    if (registrationId.equals("naver")) {
+      return new NaverUserInfo(oAuth2User.getAttributes());
+    }
+    return null;
+  }
+
+  private User processUser(OAuth2UserInfo oAuth2UserInfo) {
+    User existData = userRepository.findByProviderId(oAuth2UserInfo.getProviderId());
+
+    if (existData == null) {
+      return createUser(oAuth2UserInfo);
+    }
+
+    return updateUser(existData, oAuth2UserInfo);
+  }
+
+  private User createUser(OAuth2UserInfo oAuth2UserInfo) {
+    User userEntity = new User();
+
+    try {
+      Provider providerEnum = Provider.valueOf(oAuth2UserInfo.getProvider().toUpperCase());
+      userEntity.setProvider(providerEnum);
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException("지원하지 않는 소셜 로그인 Provider입니다: " + oAuth2UserInfo.getProvider());
+    }
+
+    userEntity.setProviderId(oAuth2UserInfo.getProviderId());
+    userEntity.setEmail(oAuth2UserInfo.getEmail());
+    userEntity.setName(oAuth2UserInfo.getName());
+    userEntity.setRole(Role.USER);
+    userRepository.save(userEntity);
+    return userEntity;
+  }
+
+  private User updateUser(User user, OAuth2UserInfo oAuth2UserInfo) {
+    user.setEmail(oAuth2UserInfo.getEmail());
+    user.setName(oAuth2UserInfo.getName());
+    userRepository.save(user);
+    return user;
+  }
+}

--- a/src/main/resources/application-sample.yml
+++ b/src/main/resources/application-sample.yml
@@ -1,3 +1,6 @@
+serve:
+  name:
+
 spring:
   datasource:
     url:
@@ -10,6 +13,23 @@ spring:
     properties:
       hibernate:
         format_sql:
+  security:
+    oauth2:
+      client:
+        registration:
+          naver:
+            client-name:
+            client-id:
+            client-secret:
+            redirect-uri:
+            authorization-grant-type:
+            scope:
+        provider:
+          naver:
+            authorization-uri:
+            token-uri:
+            user-info-uri:
+            user-name-attribute:
 
 swagger:
   enabled:
@@ -29,3 +49,8 @@ clova:
   hcx007:
     url:
     key:
+
+jwt:
+  secret:
+  access-token-expiration:
+  refresh-token-expiration:


### PR DESCRIPTION
- 연관 이슈
이 PR이 해결하는 이슈: `Closes #9 ` (병합 시 자동으로 이슈 닫힘)

- 작업 사항
    - Naver 소셜 로그인 연동하여 내부 jwt 로직 구현
        - 리프레시 토큰 로테이션(Refresh Token Rotation) 사용하여 한번 사용한 리프레시 토큰은 재사용하지 못하도록 수정
        - jwt 반환구조 
            - `AccessToken`: HTTP 응답 본문에 JSON 형태로 직접 반환
            - `RefreshToken`: HTTP 응답 헤더의 쿠키에 담아 반환 (보안을 위해 자바스크립트가 직접 접근할 수 없도록 HttpOnly 옵션을 설정)
         - `auth/reissue`
            -> 유효한 refreshToken으로 accessToken를 재발급
            -> 해당 API는 로그인 시 발급된 refreshToken 쿠키를 자동으로 사용하여 작동
         - `oauth2/authorization/naver`
             -> 소셜 로그인에 사용 할 api
    - Swagger에서 api별로 BearerToken  (http, Bearer) 입력 할 수 있도록 수정

- 테스트
    1. `/oauth2/authorization/naver` 해당 주소 요청시 Naver 소셜 로그인 창 뜨는 것 확인 및 엑세스 토큰, 리프레시 토큰 발급 확인
    2. `auth/reissue` 쿠키에서 자동으로 리프레시 토큰 넘겨서 엑세스 토큰 제작 확인
    3. `auth/reissue` 에서 유효하지 않은 리프레스 토큰으로 요청이 예외처리 반환 확인
        <img width="976" height="591" alt="image" src="https://github.com/user-attachments/assets/8214ae71-87cd-4aef-b2a9-d28c3d00b78c" />


- 주의점
    - application.yml 변경점 존재