### PR TITLE
feat(#14): 사용자의 답변 채점, 풀이 기록 저장 api(회원, 비회원)

### DIFF
--- a/src/main/java/org/quizly/quizly/configuration/SecurityConfig.java
+++ b/src/main/java/org/quizly/quizly/configuration/SecurityConfig.java
@@ -58,7 +58,8 @@ public class SecurityConfig {
                 "/swagger-ui/**",
                 "/api-docs/**",
                 "/auth/reissue",
-                "/quizzes/guest"
+                "/quizzes/guest",
+                "/quizzes/{quizId}/answer/guest"
             ).permitAll()
             .anyRequest().authenticated());
 

--- a/src/main/java/org/quizly/quizly/core/domin/repository/SolveHistoryRepository.java
+++ b/src/main/java/org/quizly/quizly/core/domin/repository/SolveHistoryRepository.java
@@ -1,0 +1,8 @@
+package org.quizly.quizly.core.domin.repository;
+
+import org.quizly.quizly.core.domin.entity.SolveHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SolveHistoryRepository extends JpaRepository<SolveHistory, Long> {
+
+}

--- a/src/main/java/org/quizly/quizly/quiz/controller/post/GradeGuestQuizzesController.java
+++ b/src/main/java/org/quizly/quizly/quiz/controller/post/GradeGuestQuizzesController.java
@@ -1,0 +1,71 @@
+package org.quizly.quizly.quiz.controller.post;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.quizly.quizly.configuration.swagger.ApiErrorCode;
+import org.quizly.quizly.core.application.BaseResponse;
+import org.quizly.quizly.core.domin.entity.Quiz;
+import org.quizly.quizly.core.exception.error.GlobalErrorCode;
+import org.quizly.quizly.quiz.dto.request.GradeQuizzesRequest;
+import org.quizly.quizly.quiz.dto.response.GradeQuizzesResponse;
+import org.quizly.quizly.quiz.service.GradeGuestQuizzesService;
+import org.quizly.quizly.quiz.service.GradeGuestQuizzesService.GradeGuestQuizzesErrorCode;
+import org.quizly.quizly.quiz.service.GradeGuestQuizzesService.GradeGuestQuizzesRequest;
+import org.quizly.quizly.quiz.service.GradeGuestQuizzesService.GradeGuestQuizzesResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "Quiz", description = "퀴즈")
+public class GradeGuestQuizzesController {
+
+  private final GradeGuestQuizzesService gradeGuestQuizzesService;
+
+  @Operation(
+      summary = "비회원 문제 채점 API",
+      description = "비회원 전용 API로 답변을 제출하면 문제를 채점합니다.\n\n비회원 API로 토큰 없이 호출합니다.\n\nuserAnswer : 객관식의 경우 TRUE/FALSE, 주관식의 경우 String 형식으로 답변을 입력받습니다.",
+      operationId = "/quizzes/{quizId}/answer/guest"
+  )
+  @PostMapping("/quizzes/{quizId}/answer/guest")
+  @ApiErrorCode(errorCodes = {GlobalErrorCode.class, GradeGuestQuizzesErrorCode.class})
+  public ResponseEntity<GradeQuizzesResponse> gradeGuestQuizzes(
+      @PathVariable(name = "quizId") @Schema(description = "문제 ID", example = "1") Long quizId,
+      @RequestBody GradeQuizzesRequest request) {
+    GradeGuestQuizzesResponse serviceResponse = gradeGuestQuizzesService.execute(
+        GradeGuestQuizzesRequest.builder()
+            .quizId(quizId)
+            .userAnswer(request.getUserAnswer())
+            .build()
+    );
+
+    if (serviceResponse == null || !serviceResponse.isSuccess()) {
+      Optional.ofNullable(serviceResponse)
+          .map(BaseResponse::getErrorCode)
+          .ifPresentOrElse(errorCode -> {
+            throw errorCode.toException();
+          }, () -> {
+            throw GlobalErrorCode.INTERNAL_ERROR.toException();
+          });
+    }
+
+    Quiz quiz = serviceResponse.getQuiz();
+    if (quiz == null) {
+      throw GlobalErrorCode.INTERNAL_ERROR.toException();
+    }
+
+    return ResponseEntity.ok(
+        GradeQuizzesResponse.builder()
+            .quizId(quiz.getId())
+            .isCorrect(serviceResponse.isCorrect())
+            .Answer(quiz.getAnswer())
+            .explanation(quiz.getExplanation())
+            .build());
+  }
+}

--- a/src/main/java/org/quizly/quizly/quiz/controller/post/GradeMemberQuizzesController.java
+++ b/src/main/java/org/quizly/quizly/quiz/controller/post/GradeMemberQuizzesController.java
@@ -9,13 +9,15 @@ import org.quizly.quizly.configuration.swagger.ApiErrorCode;
 import org.quizly.quizly.core.application.BaseResponse;
 import org.quizly.quizly.core.domin.entity.Quiz;
 import org.quizly.quizly.core.exception.error.GlobalErrorCode;
+import org.quizly.quizly.oauth.UserPrincipal;
 import org.quizly.quizly.quiz.dto.request.GradeQuizzesRequest;
 import org.quizly.quizly.quiz.dto.response.GradeQuizzesResponse;
-import org.quizly.quizly.quiz.service.GradeGuestQuizzesService;
-import org.quizly.quizly.quiz.service.GradeGuestQuizzesService.GradeGuestQuizzesErrorCode;
-import org.quizly.quizly.quiz.service.GradeGuestQuizzesService.GradeGuestQuizzesRequest;
-import org.quizly.quizly.quiz.service.GradeGuestQuizzesService.GradeGuestQuizzesResponse;
+import org.quizly.quizly.quiz.service.GradeMemberQuizzesService;
+import org.quizly.quizly.quiz.service.GradeMemberQuizzesService.GradeMemberQuizzesErrorCode;
+import org.quizly.quizly.quiz.service.GradeMemberQuizzesService.GradeMemberQuizzesRequest;
+import org.quizly.quizly.quiz.service.GradeMemberQuizzesService.GradeMemberQuizzesResponse;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -24,24 +26,26 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @Tag(name = "Quiz", description = "퀴즈")
-public class GradeGuestQuizzesController {
+public class GradeMemberQuizzesController {
 
-  private final GradeGuestQuizzesService gradeGuestQuizzesService;
+  private final GradeMemberQuizzesService gradeMemberQuizzesService;
 
   @Operation(
-      summary = "비회원 문제 채점 API",
-      description = "비회원 전용 API로 답변을 제출하면 문제를 채점합니다.\n\n비회원 API로 토큰 없이 호출합니다.\n\nuserAnswer : 객관식의 경우 TRUE/FALSE, 주관식의 경우 String 형식으로 답변을 입력받습니다.",
-      operationId = "/quizzes/{quizId}/answer/guest"
+      summary = "회원 문제 채점 API",
+      description = "회원 전용 API로 답변을 제출하면 문제를 채점, 풀이 기록을 저장합니다.\n\n회원 API로 요청 시 토큰이 필요합니다.\n\nuserAnswer : 객관식의 경우 TRUE/FALSE, 주관식의 경우 String 형식으로 답변을 입력받습니다.",
+      operationId = "/quizzes/{quizId}/answer/member"
   )
-  @PostMapping("/quizzes/{quizId}/answer/guest")
-  @ApiErrorCode(errorCodes = {GlobalErrorCode.class, GradeGuestQuizzesErrorCode.class})
-  public ResponseEntity<GradeQuizzesResponse> gradeGuestQuizzes(
+  @PostMapping("/quizzes/{quizId}/answer/member")
+  @ApiErrorCode(errorCodes = {GlobalErrorCode.class, GradeMemberQuizzesErrorCode.class})
+  public ResponseEntity<GradeQuizzesResponse> gradeMemberQuizzes(
       @PathVariable(name = "quizId") @Schema(description = "문제 ID", example = "1") Long quizId,
+      @AuthenticationPrincipal UserPrincipal userPrincipal,
       @RequestBody GradeQuizzesRequest request) {
-    GradeGuestQuizzesResponse serviceResponse = gradeGuestQuizzesService.execute(
-        GradeGuestQuizzesRequest.builder()
+    GradeMemberQuizzesResponse serviceResponse = gradeMemberQuizzesService.execute(
+        GradeMemberQuizzesRequest.builder()
             .quizId(quizId)
             .userAnswer(request.getUserAnswer())
+            .userPrincipal(userPrincipal)
             .build()
     );
 
@@ -69,3 +73,4 @@ public class GradeGuestQuizzesController {
             .build());
   }
 }
+

--- a/src/main/java/org/quizly/quizly/quiz/dto/request/GradeQuizzesRequest.java
+++ b/src/main/java/org/quizly/quizly/quiz/dto/request/GradeQuizzesRequest.java
@@ -1,0 +1,26 @@
+package org.quizly.quizly.quiz.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.quizly.quizly.core.application.BaseRequest;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "퀴즈 채점 요청")
+public class GradeQuizzesRequest implements BaseRequest {
+
+  @Schema(description = "사용자 답변 ", example = "대규모 릴리즈")
+  private String userAnswer;
+
+  @Override
+  public boolean isValid() {
+    return userAnswer != null && !userAnswer.isEmpty();
+  }
+}

--- a/src/main/java/org/quizly/quizly/quiz/dto/response/GradeQuizzesResponse.java
+++ b/src/main/java/org/quizly/quizly/quiz/dto/response/GradeQuizzesResponse.java
@@ -24,7 +24,7 @@ public class GradeQuizzesResponse {
   private boolean isCorrect;
 
   @Schema(description = "정답", example = "대규모 릴리즈")
-  private String Answer;
+  private String answer;
 
   @Schema(description = "해설", example =  "XP는 소규모 릴리즈를 기본 원리로 하며, 대규모 릴리즈는 XP의 원리에 포함되지 않는다.")
   private String explanation;

--- a/src/main/java/org/quizly/quizly/quiz/dto/response/GradeQuizzesResponse.java
+++ b/src/main/java/org/quizly/quizly/quiz/dto/response/GradeQuizzesResponse.java
@@ -1,0 +1,31 @@
+package org.quizly.quizly.quiz.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@Setter
+@SuperBuilder
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+@Schema(description = "문제 채점 응답")
+public class GradeQuizzesResponse {
+
+  @Schema(description = "문제 ID", example = "1")
+  private Long quizId;
+
+  @Schema(description = "정답 여부", example = "TRUE")
+  private boolean isCorrect;
+
+  @Schema(description = "정답", example = "대규모 릴리즈")
+  private String Answer;
+
+  @Schema(description = "해설", example =  "XP는 소규모 릴리즈를 기본 원리로 하며, 대규모 릴리즈는 XP의 원리에 포함되지 않는다.")
+  private String explanation;
+}

--- a/src/main/java/org/quizly/quizly/quiz/service/GradeGuestQuizzesService.java
+++ b/src/main/java/org/quizly/quizly/quiz/service/GradeGuestQuizzesService.java
@@ -1,0 +1,115 @@
+package org.quizly.quizly.quiz.service;
+
+import java.util.Optional;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+import lombok.extern.log4j.Log4j2;
+import org.quizly.quizly.core.application.BaseRequest;
+import org.quizly.quizly.core.application.BaseResponse;
+import org.quizly.quizly.core.application.BaseService;
+import org.quizly.quizly.core.domin.entity.Quiz;
+import org.quizly.quizly.core.domin.repository.QuizRepository;
+import org.quizly.quizly.core.exception.DomainException;
+import org.quizly.quizly.core.exception.error.BaseErrorCode;
+import org.quizly.quizly.quiz.service.GradeGuestQuizzesService.GradeGuestQuizzesRequest;
+import org.quizly.quizly.quiz.service.GradeGuestQuizzesService.GradeGuestQuizzesResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+
+@Log4j2
+@Service
+@RequiredArgsConstructor
+public class GradeGuestQuizzesService implements BaseService<GradeGuestQuizzesRequest, GradeGuestQuizzesResponse> {
+
+  private final QuizRepository quizRepository;
+
+  @Override
+  public GradeGuestQuizzesResponse execute(GradeGuestQuizzesRequest request) {
+    if (request == null || !request.isValid()) {
+      return GradeGuestQuizzesResponse.builder()
+          .success(false)
+          .errorCode(GradeGuestQuizzesErrorCode.NOT_EXIST_REQUIRED_PARAMETER)
+          .build();
+    }
+
+    Optional<Quiz> optionalQuiz = quizRepository.findById(request.getQuizId());
+    if (optionalQuiz.isEmpty()) {
+      return GradeGuestQuizzesResponse.builder()
+          .success(false)
+          .errorCode(GradeGuestQuizzesErrorCode.QUIZ_NOT_FOUND)
+          .build();
+    }
+
+    Quiz quiz = optionalQuiz.get();
+
+    String normalizedCorrectAnswer = normalizeText(quiz.getAnswer());
+    String normalizedUserAnswer = normalizeText(request.getUserAnswer());
+    boolean isCorrect = normalizedCorrectAnswer.equals(normalizedUserAnswer);
+
+    return GradeGuestQuizzesResponse.builder()
+        .quiz(quiz)
+        .isCorrect(isCorrect)
+        .build();
+  }
+
+  private String normalizeText(String text) {
+    if (text == null) {
+      return "";
+    }
+    return text.trim().toUpperCase();
+  }
+
+
+  @Getter
+  @RequiredArgsConstructor
+  public enum GradeGuestQuizzesErrorCode implements BaseErrorCode<DomainException> {
+
+    NOT_EXIST_REQUIRED_PARAMETER(HttpStatus.BAD_REQUEST, "요청 파라미터가 존재하지 않습니다."),
+    QUIZ_NOT_FOUND(HttpStatus.NOT_FOUND, "퀴즈를 찾을 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+
+    private final String message;
+
+    @Override
+    public DomainException toException() {
+      return new DomainException(httpStatus, this);
+    }
+  }
+
+  @Getter
+  @Setter
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @ToString
+  public static class GradeGuestQuizzesRequest implements BaseRequest {
+
+    private Long quizId;
+
+    private String userAnswer;
+
+    @Override
+    public boolean isValid() {
+      return quizId != null && userAnswer != null;
+    }
+  }
+
+  @Getter
+  @Setter
+  @SuperBuilder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @ToString
+  public static class GradeGuestQuizzesResponse extends BaseResponse<GradeGuestQuizzesErrorCode> {
+    private Quiz quiz;
+    private boolean isCorrect;
+  }
+
+}

--- a/src/main/java/org/quizly/quizly/quiz/service/GradeMemberQuizzesService.java
+++ b/src/main/java/org/quizly/quizly/quiz/service/GradeMemberQuizzesService.java
@@ -1,0 +1,171 @@
+package org.quizly.quizly.quiz.service;
+
+import java.util.Optional;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+import lombok.extern.log4j.Log4j2;
+import org.quizly.quizly.core.application.BaseRequest;
+import org.quizly.quizly.core.application.BaseResponse;
+import org.quizly.quizly.core.application.BaseService;
+import org.quizly.quizly.core.domin.entity.Quiz;
+import org.quizly.quizly.core.domin.entity.SolveHistory;
+import org.quizly.quizly.core.domin.entity.User;
+import org.quizly.quizly.core.domin.repository.QuizRepository;
+import org.quizly.quizly.core.domin.repository.SolveHistoryRepository;
+import org.quizly.quizly.core.domin.repository.UserRepository;
+import org.quizly.quizly.core.exception.DomainException;
+import org.quizly.quizly.core.exception.error.BaseErrorCode;
+import org.quizly.quizly.oauth.UserPrincipal;
+import org.quizly.quizly.quiz.service.GradeMemberQuizzesService.GradeMemberQuizzesRequest;
+import org.quizly.quizly.quiz.service.GradeMemberQuizzesService.GradeMemberQuizzesResponse;
+import org.quizly.quizly.quiz.service.GraderQuizService.GraderQuizRequest;
+import org.quizly.quizly.quiz.service.GraderQuizService.GraderQuizResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Log4j2
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class GradeMemberQuizzesService implements
+    BaseService<GradeMemberQuizzesRequest, GradeMemberQuizzesResponse> {
+
+  private final QuizRepository quizRepository;
+  private final UserRepository userRepository;
+  private final SolveHistoryRepository solveHistoryRepository;
+  private final GraderQuizService graderQuizService;
+
+  @Override
+  public GradeMemberQuizzesResponse execute(GradeMemberQuizzesRequest request) {
+    if (request == null || !request.isValid()) {
+      return GradeMemberQuizzesResponse.builder()
+          .success(false)
+          .errorCode(GradeMemberQuizzesErrorCode.NOT_EXIST_REQUIRED_PARAMETER)
+          .build();
+    }
+
+    String providerId = request.getUserPrincipal().getProviderId();
+    if (providerId == null || providerId.isBlank()) {
+      return GradeMemberQuizzesResponse.builder()
+          .success(false)
+          .errorCode(GradeMemberQuizzesErrorCode.NOT_EXIST_PROVIDER_ID)
+          .build();
+    }
+    User user = userRepository.findByProviderId(providerId);
+    if (user == null) {
+      log.error("[GradeMemberQuizzesService] User not found for providerId: {}", providerId);
+      return GradeMemberQuizzesResponse.builder()
+          .success(false)
+          .errorCode(GradeMemberQuizzesErrorCode.NOT_FOUND_USER)
+          .build();
+    }
+
+    Optional<Quiz> optionalQuiz = quizRepository.findById(request.getQuizId());
+    if (optionalQuiz.isEmpty()) {
+      return GradeMemberQuizzesResponse.builder()
+          .success(false)
+          .errorCode(GradeMemberQuizzesErrorCode.QUIZ_NOT_FOUND)
+          .build();
+    }
+    Quiz quiz = optionalQuiz.get();
+
+    if (quiz.getUser() == null || !quiz.getUser().equals(user)) {
+      log.error("[GradeMemberQuizzesService] Cannot solve other quiz userId: {}, quizId: {} ", user.getId(), quiz.getId());
+      return GradeMemberQuizzesResponse.builder()
+          .success(false)
+          .errorCode(GradeMemberQuizzesErrorCode.CANNOT_SOLVE_OTHER_QUIZ)
+          .build();
+    }
+
+    GraderQuizResponse graderQuizResponse = graderQuizService.execute(
+        GraderQuizRequest.builder()
+            .answer(quiz.getAnswer())
+            .userAnswer(request.getUserAnswer())
+            .build());
+    if (graderQuizResponse == null || !graderQuizResponse.isSuccess()) {
+      return GradeMemberQuizzesResponse.builder()
+          .success(false)
+          .errorCode(GradeMemberQuizzesErrorCode.GRADE_FAILED)
+          .build();
+    }
+    boolean isCorrect = graderQuizResponse.isCorrect();
+
+    saveSolveHistory(user, quiz, request.getUserAnswer(), isCorrect);
+
+    return GradeMemberQuizzesResponse.builder()
+        .quiz(quiz)
+        .isCorrect(isCorrect)
+        .build();
+  }
+
+  private void saveSolveHistory(User user, Quiz quiz, String userAnswer, boolean isCorrect) {
+    SolveHistory solveHistory = SolveHistory.builder()
+        .user(user)
+        .quiz(quiz)
+        .isCorrect(isCorrect)
+        .userAnswer(userAnswer)
+        .build();
+    solveHistoryRepository.save(solveHistory);
+  }
+
+  @Getter
+  @RequiredArgsConstructor
+  public enum GradeMemberQuizzesErrorCode implements BaseErrorCode<DomainException> {
+
+    NOT_EXIST_REQUIRED_PARAMETER(HttpStatus.BAD_REQUEST, "요청 파라미터가 존재하지 않습니다."),
+    QUIZ_NOT_FOUND(HttpStatus.NOT_FOUND, "퀴즈를 찾을 수 없습니다."),
+    NOT_EXIST_PROVIDER_ID(HttpStatus.BAD_REQUEST, "Provider ID가 존재하지 않습니다."),
+    NOT_FOUND_USER(HttpStatus.NOT_FOUND, "유저를 찾을 수 없습니다."),
+    CANNOT_SOLVE_OTHER_QUIZ(HttpStatus.FORBIDDEN, "다른 유저가 만든 퀴즈는 풀 수 없습니다."),
+    GRADE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "채점에 실패하였습니다.");
+
+    private final HttpStatus httpStatus;
+
+    private final String message;
+
+    @Override
+    public DomainException toException() {
+      return new DomainException(httpStatus, this);
+    }
+  }
+
+  @Getter
+  @Setter
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @ToString
+  public static class GradeMemberQuizzesRequest implements BaseRequest {
+
+    private Long quizId;
+
+    private String userAnswer;
+
+    private UserPrincipal userPrincipal;
+
+    @Override
+    public boolean isValid() {
+      return quizId != null && userAnswer != null && userPrincipal != null;
+    }
+  }
+
+  @Getter
+  @Setter
+  @SuperBuilder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @ToString
+  public static class GradeMemberQuizzesResponse extends BaseResponse<GradeMemberQuizzesErrorCode> {
+
+    private Quiz quiz;
+    private boolean isCorrect;
+  }
+
+}

--- a/src/main/java/org/quizly/quizly/quiz/service/GraderQuizService.java
+++ b/src/main/java/org/quizly/quizly/quiz/service/GraderQuizService.java
@@ -1,0 +1,98 @@
+package org.quizly.quizly.quiz.service;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+import lombok.extern.log4j.Log4j2;
+import org.quizly.quizly.core.application.BaseRequest;
+import org.quizly.quizly.core.application.BaseResponse;
+import org.quizly.quizly.core.application.BaseService;
+import org.quizly.quizly.core.exception.DomainException;
+import org.quizly.quizly.core.exception.error.BaseErrorCode;
+import org.quizly.quizly.quiz.service.GraderQuizService.GraderQuizRequest;
+import org.quizly.quizly.quiz.service.GraderQuizService.GraderQuizResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Log4j2
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class GraderQuizService implements BaseService<GraderQuizRequest, GraderQuizResponse> {
+
+  @Override
+  public GraderQuizResponse execute(GraderQuizRequest request) {
+    if (request == null || !request.isValid()) {
+      return GraderQuizResponse.builder()
+          .success(false)
+          .errorCode(GraderQuizErrorCode.NOT_EXIST_REQUIRED_PARAMETER)
+          .build();
+    }
+
+    String normalizedCorrectAnswer = normalizeText(request.getAnswer());
+    String normalizedUserAnswer = normalizeText(request.getUserAnswer());
+
+    return GraderQuizResponse.builder()
+        .isCorrect(normalizedCorrectAnswer.equals(normalizedUserAnswer))
+        .build();
+  }
+
+  private String normalizeText(String text) {
+    if (text == null) {
+      return "";
+    }
+    return text.trim().toUpperCase();
+  }
+
+  @Getter
+  @RequiredArgsConstructor
+  public enum GraderQuizErrorCode implements BaseErrorCode<DomainException> {
+
+    NOT_EXIST_REQUIRED_PARAMETER(HttpStatus.BAD_REQUEST, "요청 파라미터가 존재하지 않습니다.");
+
+    private final HttpStatus httpStatus;
+
+    private final String message;
+
+    @Override
+    public DomainException toException() {
+      return new DomainException(httpStatus, this);
+    }
+  }
+
+  @Getter
+  @Setter
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @ToString
+  public static class GraderQuizRequest implements BaseRequest {
+
+    private String answer;
+
+    private String userAnswer;
+
+    @Override
+    public boolean isValid() {
+      return answer != null && userAnswer != null;
+    }
+  }
+
+  @Getter
+  @Setter
+  @SuperBuilder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @ToString
+  public static class GraderQuizResponse extends BaseResponse<GraderQuizErrorCode> {
+
+    private boolean isCorrect;
+  }
+
+}


### PR DESCRIPTION
- 연관 이슈
이 PR이 해결하는 이슈: `Closes #14 ` (병합 시 자동으로 이슈 닫힘)

- 작업 사항
    - feat(#14): 사용자의 답변 채점 api(비회원)
        - solveHistory 저장하지 않고 채점만 하는 로직으로 개발
    - feat(#14): 사용자의 답변 채점, 풀이 기록 저장 api(회원)
        - solveHistory 저장괴 채점만 하는 로직으로 개발
        - 자신이 만든 문제만 풀 수 있도록 개발
 
    - 채점로직
        - 사용자 입력 데이터와 정답 데이터의 앞뒤 빈칸 제거 + 영어는 모두 대문자로 변환하여 비교를 통해 정답 여부 확인
- 테스트
    1. /quizzes/{quizId}/answer/member
        - 로그인 토큰을 통해 본인 제작 문제 풀이 및 채점, 풀이 기록 저장 테스트 확인하였습니다.
    2. /quizzes/{quizId}/answer/guest
        - 토큰 없이 quizId 문제 풀이 및 채점 테스트 확인하였습니다.