### PR TITLE
feat(#15): 문제 조회 api 구현 (회원)

### DIFF
--- a/src/main/java/org/quizly/quizly/core/domin/repository/QuizRepository.java
+++ b/src/main/java/org/quizly/quizly/core/domin/repository/QuizRepository.java
@@ -1,8 +1,10 @@
 package org.quizly.quizly.core.domin.repository;
 
+import java.util.List;
 import org.quizly.quizly.core.domin.entity.Quiz;
+import org.quizly.quizly.core.domin.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface QuizRepository extends JpaRepository<Quiz, Long> {
-
+  List<Quiz> findAllByUser(User user);
 }

--- a/src/main/java/org/quizly/quizly/core/domin/repository/SolveHistoryRepository.java
+++ b/src/main/java/org/quizly/quizly/core/domin/repository/SolveHistoryRepository.java
@@ -1,8 +1,14 @@
 package org.quizly.quizly.core.domin.repository;
 
+import java.util.List;
 import org.quizly.quizly.core.domin.entity.SolveHistory;
+import org.quizly.quizly.core.domin.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface SolveHistoryRepository extends JpaRepository<SolveHistory, Long> {
 
+  @Query("SELECT sh FROM SolveHistory sh WHERE sh.user = :user AND (sh.quiz.id, sh.createdAt) IN (SELECT sh2.quiz.id, MAX(sh2.createdAt) FROM SolveHistory sh2 WHERE sh2.user = :user GROUP BY sh2.quiz.id)")
+  List<SolveHistory> findLatestSolveHistoriesByUser(@Param("user") User user);
 }

--- a/src/main/java/org/quizly/quizly/quiz/controller/get/ReadQuizzesController.java
+++ b/src/main/java/org/quizly/quizly/quiz/controller/get/ReadQuizzesController.java
@@ -1,0 +1,116 @@
+package org.quizly.quizly.quiz.controller.get;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import lombok.RequiredArgsConstructor;
+import org.quizly.quizly.configuration.swagger.ApiErrorCode;
+import org.quizly.quizly.core.application.BaseResponse;
+import org.quizly.quizly.core.domin.entity.Quiz;
+import org.quizly.quizly.core.domin.entity.SolveHistory;
+import org.quizly.quizly.core.exception.error.GlobalErrorCode;
+import org.quizly.quizly.oauth.UserPrincipal;
+import org.quizly.quizly.quiz.dto.response.ReadQuizzesResponse;
+import org.quizly.quizly.quiz.dto.response.ReadQuizzesResponse.QuizGroup;
+import org.quizly.quizly.quiz.dto.response.ReadQuizzesResponse.QuizHistoryDetail;
+import org.quizly.quizly.quiz.service.ReadQuizzesService;
+import org.quizly.quizly.quiz.service.ReadQuizzesService.ReadQuizzesErrorCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "Quiz", description = "퀴즈")
+public class ReadQuizzesController {
+
+  private final ReadQuizzesService readQuizzesService;
+
+  @Operation(
+      summary = "문제 조회 API",
+      description = "회원 전용 API로 지정된 그룹화 기준에 따라 퀴즈 목록을 조회합니다. 이 API는 JWT 토큰을 필요로 합니다.\n\n"
+          + "- `groupType`: date (날짜별), topic (주제별)\n"
+          + "- 기본값: 그룹 기준이 명시되지 않으면 date로 자동 그룹화됩니다.",
+      operationId = "/quizzes"
+  )
+  @GetMapping("/quizzes")
+  @ApiErrorCode(errorCodes = {GlobalErrorCode.class, ReadQuizzesErrorCode.class})
+  public ResponseEntity<ReadQuizzesResponse> readQuizzes(
+      @RequestParam(name = "groupType", defaultValue = "date") String groupType,
+      @AuthenticationPrincipal UserPrincipal userPrincipal
+  ) {
+    ReadQuizzesService.ReadQuizzesResponse serviceResponse = readQuizzesService.execute(
+        ReadQuizzesService.ReadQuizzesRequest.builder()
+            .groupType(groupType)
+            .userPrincipal(userPrincipal)
+            .build());
+
+    if (serviceResponse == null || !serviceResponse.isSuccess()) {
+      Optional.ofNullable(serviceResponse)
+          .map(BaseResponse::getErrorCode)
+          .ifPresentOrElse(errorCode -> {
+            throw errorCode.toException();
+          }, () -> {
+            throw GlobalErrorCode.INTERNAL_ERROR.toException();
+          });
+    }
+
+    Map<Quiz, SolveHistory> solveHistoryMap =
+        Stream.ofNullable(serviceResponse.getSolveHistoryList())
+            .flatMap(List::stream)
+            .collect(Collectors.toMap(SolveHistory::getQuiz, Function.identity(), (o1, o2) -> o1));
+
+    return ResponseEntity.ok(toResponse(serviceResponse.getQuizList(), solveHistoryMap, groupType));
+  }
+
+
+  private ReadQuizzesResponse toResponse(List<Quiz> quizList, Map<Quiz, SolveHistory> solveHistoryMap, String groupType) {
+    Map<String, List<Quiz>> groupedQuizMap = quizList.stream()
+        .collect(Collectors.groupingBy(getGroupingFunction(groupType)));
+
+    List<QuizGroup> quizGroupList = groupedQuizMap.entrySet().stream()
+        .map(entry -> {
+          List<QuizHistoryDetail> quizHistoryDetailList = entry.getValue().stream()
+              .map(quiz -> {
+                SolveHistory history = solveHistoryMap.get(quiz);
+                return new QuizHistoryDetail(
+                    quiz.getId(),
+                    quiz.getQuizText(),
+                    quiz.getQuizType().name(),
+                    quiz.getOptions(),
+                    quiz.getAnswer(),
+                    quiz.getExplanation(),
+                    quiz.getTopic(),
+                    history != null && Boolean.TRUE.equals(history.getIsCorrect())
+                );
+              })
+              .collect(Collectors.toList());
+
+          return QuizGroup.builder()
+              .group(entry.getKey())
+              .quizHistoryDetailList(quizHistoryDetailList)
+              .build();
+        })
+        .collect(Collectors.toList());
+
+    return ReadQuizzesResponse.builder()
+        .quizGroupList(quizGroupList)
+        .build();
+  }
+
+  private Function<Quiz, String> getGroupingFunction(String groupType) {
+    if ("topic".equalsIgnoreCase(groupType)) {
+      return Quiz::getTopic;
+    }
+    return quiz -> quiz.getCreatedAt().toLocalDate().toString();
+  }
+
+}

--- a/src/main/java/org/quizly/quizly/quiz/dto/response/ReadQuizzesResponse.java
+++ b/src/main/java/org/quizly/quizly/quiz/dto/response/ReadQuizzesResponse.java
@@ -1,0 +1,58 @@
+package org.quizly.quizly.quiz.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@NoArgsConstructor
+@ToString
+@SuperBuilder
+@Schema(description = "그룹별 문제 조회 응답")
+public class ReadQuizzesResponse {
+
+  @Schema(description = "그룹별 문제")
+  private List<QuizGroup> quizGroupList;
+
+  @Getter
+  @NoArgsConstructor
+  @ToString
+  @SuperBuilder
+  @Schema(description = "문제 그룹 정보")
+  public static class QuizGroup {
+
+    @Schema(description = "그룹명", example = "자바")
+    private String group;
+
+    @Schema(description = "해당 그룹의 풀이 결과가 포함된 문제 목록")
+    private List<QuizHistoryDetail> quizHistoryDetailList;
+  }
+
+  @Schema(description = "풀이 결과가 포함된 문제 상세 정보")
+  public record QuizHistoryDetail(
+      @Schema(description = "문제 ID", example = "1")
+      Long quizId,
+      @Schema(description = "문제", example = "XP의 기본 원리에 포함되지 않는 것은?")
+      String text,
+      @Schema(description = "문제 타입 MULTIPLE_CHOICE:객관식, TRUE_FALSE:OX", example = "MULTIPLE_CHOICE")
+      String type,
+      @Schema(description = "OX 문제는 빈 배열 반환", example = "[\n"
+          + "        \"계획 절차\",\n"
+          + "        \"대규모 릴리즈\",\n"
+          + "        \"상징(Metaphor)\",\n"
+          + "        \"지속적 통합(CI)\"\n"
+          + "      ]")
+      List<String> options,
+      @Schema(description = "정답", example = "대규모 릴리즈")
+      String answer,
+      @Schema(description = "해설", example = "XP는 소규모 릴리즈를 기본 원리로 하며,dd 대규모 릴리즈는 XP의 원리에 포함되지 않는다.")
+      String explanation,
+      @Schema(description = "주제", example = "개발 방법론")
+      String topic,
+      @Schema(description = "마지막 풀이 정답 여부", example = "true")
+      boolean isLastSolveCorrect
+  ){}
+}

--- a/src/main/java/org/quizly/quizly/quiz/service/ReadQuizzesService.java
+++ b/src/main/java/org/quizly/quizly/quiz/service/ReadQuizzesService.java
@@ -1,0 +1,128 @@
+package org.quizly.quizly.quiz.service;
+
+import java.util.Collections;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+import lombok.extern.log4j.Log4j2;
+import org.quizly.quizly.core.application.BaseRequest;
+import org.quizly.quizly.core.application.BaseResponse;
+import org.quizly.quizly.core.application.BaseService;
+import org.quizly.quizly.core.domin.entity.Quiz;
+import org.quizly.quizly.core.domin.entity.SolveHistory;
+import org.quizly.quizly.core.domin.entity.User;
+import org.quizly.quizly.core.domin.repository.QuizRepository;
+import org.quizly.quizly.core.domin.repository.SolveHistoryRepository;
+import org.quizly.quizly.core.domin.repository.UserRepository;
+import org.quizly.quizly.core.exception.DomainException;
+import org.quizly.quizly.core.exception.error.BaseErrorCode;
+import org.quizly.quizly.oauth.UserPrincipal;
+import org.quizly.quizly.quiz.service.ReadQuizzesService.ReadQuizzesRequest;
+import org.quizly.quizly.quiz.service.ReadQuizzesService.ReadQuizzesResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+
+@Log4j2
+@Service
+@RequiredArgsConstructor
+public class ReadQuizzesService implements BaseService<ReadQuizzesRequest, ReadQuizzesResponse> {
+
+  private final UserRepository userRepository;
+  private final QuizRepository quizRepository;
+  private final SolveHistoryRepository solveHistoryRepository;
+
+  @Override
+  public ReadQuizzesResponse execute(ReadQuizzesRequest request) {
+    if (request == null || !request.isValid()) {
+      return ReadQuizzesResponse.builder()
+          .success(false)
+          .errorCode(ReadQuizzesErrorCode.NOT_EXIST_REQUIRED_PARAMETER)
+          .build();
+    }
+
+    String providerId = request.getUserPrincipal().getProviderId();
+    if (providerId == null || providerId.isEmpty()) {
+      return ReadQuizzesResponse.builder()
+          .success(false)
+          .errorCode(ReadQuizzesErrorCode.NOT_EXIST_PROVIDER_ID)
+          .build();
+    }
+    User user = userRepository.findByProviderId(providerId);
+    if (user == null) {
+      log.error("[ReadQuizzesService] User not found for providerId: {}", providerId);
+      return ReadQuizzesResponse.builder()
+          .success(false)
+          .errorCode(ReadQuizzesErrorCode.NOT_FOUND_USER)
+          .build();
+    }
+
+    List<Quiz> quizList = quizRepository.findAllByUser(user);
+    if (quizList.isEmpty()) {
+      return ReadQuizzesResponse.builder()
+          .success(true)
+          .quizList(quizList)
+          .solveHistoryList(Collections.emptyList())
+          .build();
+    }
+    List<SolveHistory> latestSolveHistoryList = solveHistoryRepository.findLatestSolveHistoriesByUser(
+        user);
+
+    return ReadQuizzesResponse.builder()
+        .quizList(quizList)
+        .solveHistoryList(latestSolveHistoryList)
+        .build();
+  }
+
+  @Getter
+  @RequiredArgsConstructor
+  public enum ReadQuizzesErrorCode implements BaseErrorCode<DomainException> {
+
+    NOT_EXIST_REQUIRED_PARAMETER(HttpStatus.BAD_REQUEST, "요청 파라미터가 존재하지 않습니다."),
+    NOT_EXIST_PROVIDER_ID(HttpStatus.BAD_REQUEST, "Provider ID가 존재하지 않습니다."),
+    NOT_FOUND_USER(HttpStatus.NOT_FOUND, "유저를 찾을 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    @Override
+    public DomainException toException() {
+      return new DomainException(httpStatus, this);
+    }
+  }
+
+  @Getter
+  @Setter
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @ToString
+  public static class ReadQuizzesRequest implements BaseRequest {
+
+    private String groupType;
+    private UserPrincipal userPrincipal;
+
+    @Override
+    public boolean isValid() {
+      return groupType != null && userPrincipal != null;
+    }
+  }
+
+  @Getter
+  @Setter
+  @SuperBuilder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @ToString
+  public static class ReadQuizzesResponse extends BaseResponse<ReadQuizzesErrorCode> {
+
+    private List<Quiz> quizList;
+
+    private List<SolveHistory> solveHistoryList;
+  }
+}


### PR DESCRIPTION
- 연관 이슈
이 PR이 해결하는 이슈: `Closes #15 ` (병합 시 자동으로 이슈 닫힘)

- 작업 사항
    - 기존 레거시 코드에서는 날짜로만 조회 가능하도록 개발되어 있지만 기획 회의에서 주제별 조회에 대한 의논이 나왔어서 날짜, 주제 모두 대응하도록 개발하였습니다.
    - groupType에 `topic`, `date` 값을 넣어 요청이 가능하며 요청 타입에 따라 문제를 조회 합니다.
    - 기존 api와의 변경점을 최소화 하기 위하여 groupType 없이 요청을 할 경우 날짜별로 조회 가능하도록 하였습니다.
 
- 테스트
    1. api 요청값(groupType)에 `topic` 넣으면 주제별로 조회 테스트 확인하였습니다.
    2. api 요청값(groupType)에 `date` 넣으면 날짜별로 조회 테스트 확인하였습니다. (요청값을 명시하지 않으면 date 기준으로 나오는 것 확인하였습니다.)
<img width="726" height="618" alt="스크린샷 2025-09-18 오후 2 29 04" src="https://github.com/user-attachments/assets/d27bef51-87ad-4336-95a9-2d435fb38cf8" />
