### PR TITLE
fix(#19): 문제 조회 api N+1 이슈 해결

### DIFF
--- a/src/main/java/org/quizly/quizly/core/domin/repository/QuizRepository.java
+++ b/src/main/java/org/quizly/quizly/core/domin/repository/QuizRepository.java
@@ -4,7 +4,11 @@ import java.util.List;
 import org.quizly.quizly.core.domin.entity.Quiz;
 import org.quizly.quizly.core.domin.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface QuizRepository extends JpaRepository<Quiz, Long> {
   List<Quiz> findAllByUser(User user);
+
+  @Query("SELECT DISTINCT q FROM Quiz q LEFT JOIN FETCH q.options WHERE q.user = :user")
+  List<Quiz> findAllByUserWithOptions(User user);
 }

--- a/src/main/java/org/quizly/quizly/core/domin/repository/SolveHistoryRepository.java
+++ b/src/main/java/org/quizly/quizly/core/domin/repository/SolveHistoryRepository.java
@@ -9,6 +9,6 @@ import org.springframework.data.repository.query.Param;
 
 public interface SolveHistoryRepository extends JpaRepository<SolveHistory, Long> {
 
-  @Query("SELECT sh FROM SolveHistory sh WHERE sh.user = :user AND (sh.quiz.id, sh.createdAt) IN (SELECT sh2.quiz.id, MAX(sh2.createdAt) FROM SolveHistory sh2 WHERE sh2.user = :user GROUP BY sh2.quiz.id)")
+  @Query("SELECT sh FROM SolveHistory sh LEFT JOIN FETCH sh.quiz WHERE sh.user = :user AND (sh.quiz.id, sh.createdAt) IN (SELECT sh2.quiz.id, MAX(sh2.createdAt) FROM SolveHistory sh2 WHERE sh2.user = :user GROUP BY sh2.quiz.id)")
   List<SolveHistory> findLatestSolveHistoriesByUser(@Param("user") User user);
 }

--- a/src/main/java/org/quizly/quizly/quiz/service/ReadQuizzesService.java
+++ b/src/main/java/org/quizly/quizly/quiz/service/ReadQuizzesService.java
@@ -62,7 +62,7 @@ public class ReadQuizzesService implements BaseService<ReadQuizzesRequest, ReadQ
           .build();
     }
 
-    List<Quiz> quizList = quizRepository.findAllByUser(user);
+    List<Quiz> quizList = quizRepository.findAllByUserWithOptions(user);
     if (quizList.isEmpty()) {
       return ReadQuizzesResponse.builder()
           .success(true)


### PR DESCRIPTION
- 연관 이슈
이 PR이 해결하는 이슈: `Closes #19 ` (병합 시 자동으로 이슈 닫힘)

- 작업 사항
    - `QuizRepository`에 options 컬렉션을 LEFT JOIN FETCH로 즉시 로딩(Eager Loading)하는 새로운 메서드 findAllByUserWithOptions(User user)를 추가하여 Quiz 엔티티와 함께 options 컬렉션이 한 번의 쿼리로  로드하도록 수정
    - `SolveHistoryRepository`의 `findLatestSolveHistoriesByUser` 메서드 쿼리에 LEFT JOIN FETCH sh.quiz를 추가하여 SolveHistory 조회 시 연관된 Quiz 엔티티가 함께 로드하도록 수정

 
- 테스트
    1. 애플리케이션 콘솔 창으로 N+1 발생 안하는것으로 확인