### PR TITLE
feat(#18): 틀린 문제 조회 api (회원)

### DIFF
--- a/src/main/java/org/quizly/quizly/core/domin/repository/SolveHistoryRepository.java
+++ b/src/main/java/org/quizly/quizly/core/domin/repository/SolveHistoryRepository.java
@@ -11,4 +11,7 @@ public interface SolveHistoryRepository extends JpaRepository<SolveHistory, Long
 
   @Query("SELECT sh FROM SolveHistory sh LEFT JOIN FETCH sh.quiz WHERE sh.user = :user AND (sh.quiz.id, sh.createdAt) IN (SELECT sh2.quiz.id, MAX(sh2.createdAt) FROM SolveHistory sh2 WHERE sh2.user = :user GROUP BY sh2.quiz.id)")
   List<SolveHistory> findLatestSolveHistoriesByUser(@Param("user") User user);
+
+  @Query("SELECT sh FROM SolveHistory sh LEFT JOIN FETCH sh.quiz WHERE sh.user = :user AND sh.isCorrect = FALSE AND (sh.quiz.id, sh.createdAt) IN (SELECT sh2.quiz.id, MAX(sh2.createdAt) FROM SolveHistory sh2 WHERE sh2.user = :user GROUP BY sh2.quiz.id)")
+  List<SolveHistory> findLatestWrongSolveHistoriesByUser(@Param("user") User user);
 }

--- a/src/main/java/org/quizly/quizly/quiz/controller/get/ReadWrongQuizzesController.java
+++ b/src/main/java/org/quizly/quizly/quiz/controller/get/ReadWrongQuizzesController.java
@@ -1,0 +1,117 @@
+package org.quizly.quizly.quiz.controller.get;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import lombok.RequiredArgsConstructor;
+import org.quizly.quizly.configuration.swagger.ApiErrorCode;
+import org.quizly.quizly.core.application.BaseResponse;
+import org.quizly.quizly.core.domin.entity.Quiz;
+import org.quizly.quizly.core.domin.entity.SolveHistory;
+import org.quizly.quizly.core.exception.error.GlobalErrorCode;
+import org.quizly.quizly.oauth.UserPrincipal;
+import org.quizly.quizly.quiz.dto.response.ReadQuizzesResponse;
+import org.quizly.quizly.quiz.dto.response.ReadQuizzesResponse.QuizGroup;
+import org.quizly.quizly.quiz.dto.response.ReadQuizzesResponse.QuizHistoryDetail;
+import org.quizly.quizly.quiz.service.ReadWrongQuizzesService;
+import org.quizly.quizly.quiz.service.ReadWrongQuizzesService.ReadWrongQuizzesErrorCode;
+import org.quizly.quizly.quiz.service.ReadWrongQuizzesService.ReadWrongQuizzesRequest;
+import org.quizly.quizly.quiz.service.ReadWrongQuizzesService.ReadWrongQuizzesResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "Quiz", description = "퀴즈")
+public class ReadWrongQuizzesController {
+
+  private final ReadWrongQuizzesService readWrongQuizzesService;
+
+  @Operation(
+      summary = "틀린 문제 조회 API",
+      description = "회원 전용 API로 지정된 그룹화 기준에 따라 틀린 문제 목록을 조회합니다.\n\n이 API는 JWT 토큰을 필요로 합니다.\n\n"
+          + "- `groupType`: date (날짜별), topic (주제별)\n"
+          + "- 기본값: 그룹 기준이 명시되지 않으면 date로 자동 그룹화됩니다.",
+      operationId = "/quizzes/wrong"
+  )
+  @GetMapping("/quizzes/wrong")
+  @ApiErrorCode(errorCodes = {GlobalErrorCode.class, ReadWrongQuizzesErrorCode.class})
+  public ResponseEntity<ReadQuizzesResponse> readWrongQuizzes(
+      @RequestParam(name = "groupType", defaultValue = "date") String groupType,
+      @AuthenticationPrincipal UserPrincipal userPrincipal
+  ) {
+    ReadWrongQuizzesService.ReadWrongQuizzesResponse serviceResponse = readWrongQuizzesService.execute(
+        ReadWrongQuizzesRequest.builder()
+            .groupType(groupType)
+            .userPrincipal(userPrincipal)
+            .build());
+
+    if (serviceResponse == null || !serviceResponse.isSuccess()) {
+      Optional.ofNullable(serviceResponse)
+          .map(BaseResponse::getErrorCode)
+          .ifPresentOrElse(errorCode -> {
+            throw errorCode.toException();
+          }, () -> {
+            throw GlobalErrorCode.INTERNAL_ERROR.toException();
+          });
+    }
+
+    Map<Quiz, SolveHistory> solveHistoryMap =
+        Stream.ofNullable(serviceResponse.getSolveHistoryList())
+            .flatMap(List::stream)
+            .collect(Collectors.toMap(SolveHistory::getQuiz, Function.identity(), (o1, o2) -> o1));
+
+    return ResponseEntity.ok(toResponse(serviceResponse.getQuizList(), solveHistoryMap, groupType));
+  }
+
+  private ReadQuizzesResponse toResponse(List<Quiz> quizList, Map<Quiz, SolveHistory> solveHistoryMap, String groupType) {
+    Map<String, List<Quiz>> groupedQuizMap = quizList.stream()
+        .collect(Collectors.groupingBy(getGroupingFunction(groupType)));
+
+    List<QuizGroup> quizGroupList = groupedQuizMap.entrySet().stream()
+        .map(entry -> {
+          List<QuizHistoryDetail> quizHistoryDetailList = entry.getValue().stream()
+              .map(quiz -> {
+                SolveHistory history = solveHistoryMap.get(quiz);
+                return new QuizHistoryDetail(
+                    quiz.getId(),
+                    quiz.getQuizText(),
+                    quiz.getQuizType().name(),
+                    quiz.getOptions(),
+                    quiz.getAnswer(),
+                    quiz.getExplanation(),
+                    quiz.getTopic(),
+                    (history.getIsCorrect())
+                );
+              })
+              .collect(Collectors.toList());
+
+          return QuizGroup.builder()
+              .group(entry.getKey())
+              .quizHistoryDetailList(quizHistoryDetailList)
+              .build();
+        })
+        .collect(Collectors.toList());
+
+    return ReadQuizzesResponse.builder()
+        .quizGroupList(quizGroupList)
+        .build();
+  }
+
+  private Function<Quiz, String> getGroupingFunction(String groupType) {
+    if ("topic".equalsIgnoreCase(groupType)) {
+      return Quiz::getTopic;
+    }
+    return quiz -> quiz.getCreatedAt().toLocalDate().toString();
+  }
+
+}

--- a/src/main/java/org/quizly/quizly/quiz/service/ReadWrongQuizzesService.java
+++ b/src/main/java/org/quizly/quizly/quiz/service/ReadWrongQuizzesService.java
@@ -1,0 +1,119 @@
+package org.quizly.quizly.quiz.service;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+import lombok.extern.log4j.Log4j2;
+import org.quizly.quizly.core.application.BaseRequest;
+import org.quizly.quizly.core.application.BaseResponse;
+import org.quizly.quizly.core.application.BaseService;
+import org.quizly.quizly.core.domin.entity.Quiz;
+import org.quizly.quizly.core.domin.entity.SolveHistory;
+import org.quizly.quizly.core.domin.entity.User;
+import org.quizly.quizly.core.domin.repository.SolveHistoryRepository;
+import org.quizly.quizly.core.domin.repository.UserRepository;
+import org.quizly.quizly.core.exception.DomainException;
+import org.quizly.quizly.core.exception.error.BaseErrorCode;
+import org.quizly.quizly.oauth.UserPrincipal;
+import org.quizly.quizly.quiz.service.ReadWrongQuizzesService.ReadWrongQuizzesRequest;
+import org.quizly.quizly.quiz.service.ReadWrongQuizzesService.ReadWrongQuizzesResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+
+@Log4j2
+@Service
+@RequiredArgsConstructor
+public class ReadWrongQuizzesService implements BaseService<ReadWrongQuizzesRequest, ReadWrongQuizzesResponse> {
+
+  private final UserRepository userRepository;
+  private final SolveHistoryRepository solveHistoryRepository;
+
+  @Override
+  public ReadWrongQuizzesResponse execute(ReadWrongQuizzesRequest request) {
+    if (request == null || !request.isValid()) {
+      return ReadWrongQuizzesResponse.builder()
+          .success(false)
+          .errorCode(ReadWrongQuizzesErrorCode.NOT_EXIST_REQUIRED_PARAMETER)
+          .build();
+    }
+
+    String providerId = request.getUserPrincipal().getProviderId();
+    if (providerId == null || providerId.isEmpty()) {
+      return ReadWrongQuizzesResponse.builder()
+          .success(false)
+          .errorCode(ReadWrongQuizzesErrorCode.NOT_EXIST_PROVIDER_ID)
+          .build();
+    }
+    User user = userRepository.findByProviderId(providerId);
+    if (user == null) {
+      log.error("[ReadWrongQuizzesService] User not found for providerId: {}", providerId);
+      return ReadWrongQuizzesResponse.builder()
+          .success(false)
+          .errorCode(ReadWrongQuizzesErrorCode.NOT_FOUND_USER)
+          .build();
+    }
+
+    List<SolveHistory> wrongSolveHistoryList = solveHistoryRepository.findLatestWrongSolveHistoriesByUser(user);
+
+    List<Quiz> wrongQuizList = wrongSolveHistoryList.stream()
+        .map(SolveHistory::getQuiz)
+        .toList();
+
+    return ReadWrongQuizzesResponse.builder()
+        .quizList(wrongQuizList)
+        .solveHistoryList(wrongSolveHistoryList)
+        .build();
+  }
+
+  @Getter
+  @RequiredArgsConstructor
+  public enum ReadWrongQuizzesErrorCode implements BaseErrorCode<DomainException> {
+
+    NOT_EXIST_REQUIRED_PARAMETER(HttpStatus.BAD_REQUEST, "요청 파라미터가 존재하지 않습니다."),
+    NOT_EXIST_PROVIDER_ID(HttpStatus.BAD_REQUEST, "Provider ID가 존재하지 않습니다."),
+    NOT_FOUND_USER(HttpStatus.NOT_FOUND, "유저를 찾을 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    @Override
+    public DomainException toException() {
+      return new DomainException(httpStatus, this);
+    }
+  }
+
+  @Getter
+  @Setter
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @ToString
+  public static class ReadWrongQuizzesRequest implements BaseRequest {
+
+    private String groupType;
+    private UserPrincipal userPrincipal;
+
+    @Override
+    public boolean isValid() {
+      return groupType != null && userPrincipal != null;
+    }
+  }
+
+  @Getter
+  @Setter
+  @SuperBuilder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @ToString
+  public static class ReadWrongQuizzesResponse extends BaseResponse<ReadWrongQuizzesErrorCode> {
+
+    private List<Quiz> quizList;
+    private List<SolveHistory> solveHistoryList;
+  }
+}


### PR DESCRIPTION
- 연관 이슈
이 PR이 해결하는 이슈: `Closes #18 ` (병합 시 자동으로 이슈 닫힘)

- 작업 사항
    - [문제 조회 api](https://github.com/Quizly-Team/backend/pull/17) 와 비슷한 구조로 개발 진행하였습니다.
    - groupType에 `topic`, `date` 값을 넣어 요청이 가능하며 요청 타입에 따라 "사용자의 틀린 문제"를 조회 합니다.
    - 기존 api와의 변경점을 최소화 하기 위하여 groupType 없이 요청을 할 경우 날짜별로 "사용자의 틀린 문제" 조회 가능하도록 하였습니다.
 
- 테스트
    1. api 요청값(groupType)에 `topic` 넣으면 주제별로 "틀린 문제만" 반환되는지 테스트 확인하였습니다.
    2. api 요청값(groupType)에 `date` 넣으면 날짜별로 "틀린 문제만" 반환되는지 테스트 확인하였습니다. (요청값을 명시하지 않으면 date 기준으로 나오는 것 확인하였습니다.)
    <img width="960" height="837" alt="스크린샷 2025-09-18 오후 5 19 16" src="https://github.com/user-attachments/assets/4b756136-18ea-40c0-bed7-86833ccae1b8" />

