### PR TITLE
feat(#10): github action CICD 구현 (DEV 서버)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,0 +1,46 @@
+name: Deploy Dev to NCP Container Registry
+
+on:
+  push:
+    branches:
+      - dev
+
+jobs:
+  build-and-push:
+    name: Build and Push Docker Image
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v3
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x ./gradlew
+
+      - name: Login to NCP Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ secrets.NCP_CONTAINER_REGISTRY }}
+          username: ${{ secrets.NCP_ACCESS_KEY }}
+          password: ${{ secrets.NCP_SECRET_KEY }}
+
+      - name: Make application.yml
+        run: |
+          mkdir -p ./src/main/resources
+          echo "${{ secrets.APPLICATION_YML_DEV }}" > ./src/main/resources/application.yml
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ secrets.NCP_CONTAINER_REGISTRY }}/${{ secrets.DOCKER_IMAGE_NAME }}:latest
+            ${{ secrets.NCP_CONTAINER_REGISTRY }}/${{ secrets.DOCKER_IMAGE_NAME }}:${{ github.sha }}
+        

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,4 @@ FROM openjdk:17-slim
 WORKDIR /app
 COPY --from=build /app/build/libs/*.jar app.jar
 EXPOSE 8080
-ENTRYPOINT ["java","-jar","/app.jar"]
+ENTRYPOINT ["java","-jar","app.jar"]


### PR DESCRIPTION
- 연관 이슈
이 PR이 해결하는 이슈: `Closes #10 ` (병합 시 자동으로 이슈 닫힘)

- 작업 사항
    - dev 브랜치에 merge 발생 시 자동 배포 가능하도록 CICD 구현
    - "하나의 NCP 서버" 위에 모든 서비스(애플리케이션, DB, Watchtower)가 별도의 Docker 컨테이너로 실행
    -  CICD 흐름
        1.. 개발자가 GitHub에 코드를 dev 브랜치에 푸시하면 "GitHub Actions"가 Docker 이미지를 빌드
        2. 빌드된 이미지는 "NCP Container Registry" (이미지 저장소)에 업로드
        3. 서버에서 실행 중인 "Watchtower"가 새 이미지를 감지하고 애플리케이션 컨테이너를 자동 업데이트
        4. 업데이트된 애플리케이션 컨테이너는 같은 서버에 있는 MySQL 컨테이너와 Docker 내부 네트워크로 통신
    - 자세한 구축 과정은 [노션](https://chanyoung-kwon.notion.site/CICD-271e5ea23d6b80ff9dd2db99f8c37806?source=copy_link) 참고
 
- 테스트
    <img width="1439" height="163" alt="스크린샷 2025-09-23 오후 2 47 07" src="https://github.com/user-attachments/assets/4d419c9e-5221-46e8-8779-6b100453f8cb" />
    -> quizly-app 컨테어너 확인시 CREATE의 값이 자동으로 업데이트 한 것을 확인

- 주의점
    - 배포 시에 사용하는 application.yml 파일의 경우 해당 레포지토리의 settings/secrets/actions `APPLICATION_YML_DEV`에서 주입 받아서 사용중
    - 따라서 application.yml 파일 변경시 `APPLICATION_YML_DEV` 키의 값 수정 필수