### PR TITLE
feat(#30): Ocr 문제 생성 api 구현(코드 활용)

### DIFF
--- a/src/main/java/org/quizly/quizly/configuration/SecurityConfig.java
+++ b/src/main/java/org/quizly/quizly/configuration/SecurityConfig.java
@@ -58,7 +58,7 @@ public class SecurityConfig {
                 "/swagger-ui/**",
                 "/api-docs/**",
                 "/auth/reissue",
-                "/quizzes/guest",
+                "/quizzes/guest/**",
                 "/quizzes/{quizId}/answer/guest"
             ).permitAll()
             .anyRequest().authenticated());

--- a/src/main/java/org/quizly/quizly/external/ocr/dto/Request/OcrRequestDto.java
+++ b/src/main/java/org/quizly/quizly/external/ocr/dto/Request/OcrRequestDto.java
@@ -1,0 +1,27 @@
+package org.quizly.quizly.external.ocr.dto.Request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class OcrRequestDto {
+
+    private List<Image> images;
+    private String requestId;
+    private String version;
+    private long timestamp;
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Image {
+        private String format;
+        private String name;
+    }
+}
+

--- a/src/main/java/org/quizly/quizly/external/ocr/dto/Response/OcrResponseDto.java
+++ b/src/main/java/org/quizly/quizly/external/ocr/dto/Response/OcrResponseDto.java
@@ -1,0 +1,40 @@
+package org.quizly.quizly.external.ocr.dto.Response;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class OcrResponseDto {
+    private String version;
+    private String requestId;
+    private long timestamp;
+    private List<ImageResult> images;
+
+    @Getter
+    @NoArgsConstructor
+    public static class ImageResult {
+        private List<Field> fields;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class Field {
+        private String inferText;
+    }
+
+    public String getFullText() {
+        if (images == null || images.isEmpty()) return "";
+        StringBuilder sb = new StringBuilder();
+        for (ImageResult image : images) {
+            if (image.getFields() != null) {
+                for (Field field : image.getFields()) {
+                    sb.append(field.getInferText()).append(" ");
+                }
+            }
+        }
+        return sb.toString().trim();
+    }
+}

--- a/src/main/java/org/quizly/quizly/external/ocr/property/OcrProperty.java
+++ b/src/main/java/org/quizly/quizly/external/ocr/property/OcrProperty.java
@@ -1,0 +1,15 @@
+package org.quizly.quizly.external.ocr.property;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Getter
+@Setter
+@Configuration
+@ConfigurationProperties(prefix = "ocr.api")
+public class OcrProperty {
+    private String url;
+    private String secret;
+}

--- a/src/main/java/org/quizly/quizly/external/ocr/service/ClovaOcrService.java
+++ b/src/main/java/org/quizly/quizly/external/ocr/service/ClovaOcrService.java
@@ -1,0 +1,70 @@
+package org.quizly.quizly.external.ocr.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import okhttp3.*;
+import org.quizly.quizly.external.ocr.dto.Request.OcrRequestDto;
+import org.quizly.quizly.external.ocr.dto.Response.OcrResponseDto;
+import org.quizly.quizly.external.ocr.property.OcrProperty;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+public class ClovaOcrService {
+
+    private final OcrProperty ocrProperty;
+    private final ObjectMapper objectMapper;
+    private final OkHttpClient client = new OkHttpClient.Builder()
+            .connectTimeout(120, TimeUnit.SECONDS)
+            .writeTimeout(120, TimeUnit.SECONDS)
+            .readTimeout(120, TimeUnit.SECONDS)
+            .build();
+
+    public OcrResponseDto extractTextFromImage(MultipartFile imageFile) {
+        try {
+            String fileExtension = getFileExtension(imageFile.getOriginalFilename());
+
+            OcrRequestDto ocrRequest = new OcrRequestDto(
+                    Collections.singletonList(new OcrRequestDto.Image(fileExtension, "quiz-image")),
+                    UUID.randomUUID().toString(),
+                    "V2",
+                    System.currentTimeMillis()
+            );
+
+            RequestBody requestBody = new MultipartBody.Builder()
+                    .setType(MultipartBody.FORM)
+                    .addFormDataPart("message", objectMapper.writeValueAsString(ocrRequest))
+                    .addFormDataPart("file", imageFile.getOriginalFilename(),
+                            RequestBody.create(imageFile.getBytes(), MediaType.parse(imageFile.getContentType())))
+                    .build();
+
+            Request request = new Request.Builder()
+                    .url(ocrProperty.getUrl())
+                    .header("X-OCR-SECRET", ocrProperty.getSecret())
+                    .post(requestBody)
+                    .build();
+
+            try (Response response = client.newCall(request).execute()) {
+                if (!response.isSuccessful() || response.body() == null) {
+                    throw new RuntimeException("OCR API 호출 실패: " + response);
+                }
+                String responseBody = response.body().string();
+                return objectMapper.readValue(responseBody, OcrResponseDto.class);
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("OCR 처리 중 오류 발생", e);
+        }
+    }
+
+    private String getFileExtension(String fileName) {
+        if (fileName == null || fileName.isEmpty()) return "";
+        int dotIndex = fileName.lastIndexOf('.');
+        return (dotIndex == -1) ? "" : fileName.substring(dotIndex + 1);
+    }
+}

--- a/src/main/java/org/quizly/quizly/external/ocr/service/ExtractTextFromOcrService.java
+++ b/src/main/java/org/quizly/quizly/external/ocr/service/ExtractTextFromOcrService.java
@@ -1,0 +1,21 @@
+package org.quizly.quizly.external.ocr.service;
+
+import lombok.RequiredArgsConstructor;
+import org.quizly.quizly.external.ocr.dto.Response.OcrResponseDto;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+public class ExtractTextFromOcrService {
+
+    private final ClovaOcrService clovaOcrService;
+
+    public String extractPlainText(MultipartFile file) {
+        OcrResponseDto response = clovaOcrService.extractTextFromImage(file);
+        if (response == null || response.getFullText().isBlank()) {
+            throw new IllegalArgumentException("OCR에서 텍스트를 추출할 수 없습니다.");
+        }
+        return response.getFullText();
+    }
+}

--- a/src/main/java/org/quizly/quizly/quiz/controller/post/CreateOcrGuestQuizzesController.java
+++ b/src/main/java/org/quizly/quizly/quiz/controller/post/CreateOcrGuestQuizzesController.java
@@ -1,0 +1,79 @@
+package org.quizly.quizly.quiz.controller.post;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.quizly.quizly.core.application.BaseResponse;
+import org.quizly.quizly.core.domin.entity.Quiz;
+import org.quizly.quizly.core.exception.error.GlobalErrorCode;
+import org.quizly.quizly.external.ocr.service.ExtractTextFromOcrService;
+import org.quizly.quizly.quiz.dto.response.CreateQuizzesResponse;
+import org.quizly.quizly.quiz.service.CreateGuestQuizzesService;
+import org.quizly.quizly.quiz.service.CreateGuestQuizzesService.CreateGuestQuizzesErrorCode;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+import java.util.Optional;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "Quiz", description = "퀴즈")
+public class CreateOcrGuestQuizzesController {
+
+    private final ExtractTextFromOcrService extractTextFromOcrService;
+    private final CreateGuestQuizzesService createGuestQuizzesService;
+
+    @Operation(
+            summary = "OCR 기반 비회원 퀴즈 생성 API",
+            description = "이미지(OCR) 기반으로 비회원 전용 퀴즈 3문제를 생성합니다.\n\nplainText는 OCR에서 자동 추출합니다."
+    )
+    @PostMapping(value = "/quizzes/guest/ocr", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<CreateQuizzesResponse> createOcrGuestQuizzes(
+            @RequestParam("file") MultipartFile file,
+            @RequestParam("type") Quiz.QuizType type
+    ) {
+        String plainText = extractTextFromOcrService.extractPlainText(file);
+
+        CreateGuestQuizzesService.CreateGuestQuizzesResponse serviceResponse =
+                createGuestQuizzesService.execute(
+                        CreateGuestQuizzesService.CreateGuestQuizzesRequest.builder()
+                                .plainText(plainText)
+                                .type(type)
+                                .build()
+                );
+
+        if (serviceResponse == null || !serviceResponse.isSuccess()) {
+            Optional.ofNullable(serviceResponse)
+                    .map(BaseResponse::getErrorCode)
+                    .ifPresentOrElse(errorCode -> {
+                        throw errorCode.toException();
+                    }, () -> {
+                        throw GlobalErrorCode.INTERNAL_ERROR.toException();
+                    });
+        }
+
+        return ResponseEntity.ok(toResponse(serviceResponse));
+    }
+
+
+
+    private CreateQuizzesResponse toResponse(CreateGuestQuizzesService.CreateGuestQuizzesResponse serviceResponse) {
+        List<Quiz> quizList = serviceResponse.getQuizList();
+        List<CreateQuizzesResponse.QuizDetail> quizDetailList = quizList.stream()
+                .map(quiz -> new CreateQuizzesResponse.QuizDetail(
+                        quiz.getId(),
+                        quiz.getQuizText(),
+                        quiz.getQuizType().name(),
+                        quiz.getOptions(),
+                        quiz.getAnswer(),
+                        quiz.getExplanation(),
+                        quiz.getTopic()))
+                .toList();
+        return CreateQuizzesResponse.builder()
+                .quizDetailList(quizDetailList)
+                .build();
+    }
+}

--- a/src/main/java/org/quizly/quizly/quiz/controller/post/CreateOcrMemberQuizzesController.java
+++ b/src/main/java/org/quizly/quizly/quiz/controller/post/CreateOcrMemberQuizzesController.java
@@ -1,0 +1,79 @@
+package org.quizly.quizly.quiz.controller.post;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.quizly.quizly.core.application.BaseResponse;
+import org.quizly.quizly.core.domin.entity.Quiz;
+import org.quizly.quizly.core.exception.error.GlobalErrorCode;
+import org.quizly.quizly.external.ocr.service.ExtractTextFromOcrService;
+import org.quizly.quizly.oauth.UserPrincipal;
+import org.quizly.quizly.quiz.dto.response.CreateQuizzesResponse;
+import org.quizly.quizly.quiz.service.CreateMemberQuizzesService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+import java.util.Optional;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "Quiz", description = "퀴즈")
+public class CreateOcrMemberQuizzesController {
+
+    private final ExtractTextFromOcrService extractTextFromOcrService;
+    private final CreateMemberQuizzesService createMemberQuizzesService;
+
+    @Operation(
+            summary = "OCR 기반 회원 퀴즈 생성 API",
+            description = "이미지(OCR) 기반으로 회원 전용 퀴즈 10문제를 생성합니다.\n\nplainText는 OCR에서 자동 추출합니다."
+    )
+    @PostMapping("/quizzes/member/ocr")
+    public ResponseEntity<CreateQuizzesResponse> createOcrMemberQuizzes(
+            @RequestParam("file") MultipartFile file,
+            @RequestParam("type") Quiz.QuizType type,
+            @AuthenticationPrincipal UserPrincipal userPrincipal
+    ) {
+        String plainText = extractTextFromOcrService.extractPlainText(file);
+
+        CreateMemberQuizzesService.CreateMemberQuizzesResponse serviceResponse =
+                createMemberQuizzesService.execute(
+                        CreateMemberQuizzesService.CreateMemberQuizzesRequest.builder()
+                                .plainText(plainText)
+                                .type(type)
+                                .userPrincipal(userPrincipal)
+                                .build()
+                );
+
+        if (serviceResponse == null || !serviceResponse.isSuccess()) {
+            Optional.ofNullable(serviceResponse)
+                    .map(BaseResponse::getErrorCode)
+                    .ifPresentOrElse(errorCode -> {
+                        throw errorCode.toException();
+                    }, () -> {
+                        throw GlobalErrorCode.INTERNAL_ERROR.toException();
+                    });
+        }
+
+        return ResponseEntity.ok(toResponse(serviceResponse));
+    }
+
+    private CreateQuizzesResponse toResponse(CreateMemberQuizzesService.CreateMemberQuizzesResponse serviceResponse) {
+        List<Quiz> quizList = serviceResponse.getQuizList();
+        List<CreateQuizzesResponse.QuizDetail> quizDetailList = quizList.stream()
+                .map(quiz -> new CreateQuizzesResponse.QuizDetail(
+                        quiz.getId(),
+                        quiz.getQuizText(),
+                        quiz.getQuizType().name(),
+                        quiz.getOptions(),
+                        quiz.getAnswer(),
+                        quiz.getExplanation(),
+                        quiz.getTopic()))
+                .toList();
+        return CreateQuizzesResponse.builder()
+                .quizDetailList(quizDetailList)
+                .build();
+    }
+}


### PR DESCRIPTION
- 연관 이슈
  Closes #30 

- 작업 사항
   - 기존 CreateGuestQuizzesService 와 CreateMemberQuizzesService 의 로직을 그대로 활용하여 개발했습니다.
   - 퀴즈 생성 및 검증 로직은 기존 서비스의 execute() 메서드를 그대로 사용합니다.
  - plainText 입력 부분만 OCR 결과(ExtractTextFromOcrService.extractPlainText)로 대체하였습니다.


- 테스트

  - OCR로 추출된 텍스트를 기반으로 게스트/멤버 별 퀴즈 생성이 정상적으로 이루어지는지 확인하였습니다.
  - 존재하지 않는 user의 경우 오류 메세지 확인하였습니다.
<img width="1426" height="1391" alt="image" src="https://github.com/user-attachments/assets/4c66c319-baca-4200-b5dd-bd4a663149a6" />
