### PR TITLE
feat(#34): ocr 기반 모의고사 생성 api 구현

### DIFF
--- a/src/main/java/org/quizly/quizly/mock/controller/post/CreateMemberOcrMockExamController.java
+++ b/src/main/java/org/quizly/quizly/mock/controller/post/CreateMemberOcrMockExamController.java
@@ -1,0 +1,95 @@
+package org.quizly.quizly.mock.controller.post;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.quizly.quizly.configuration.swagger.ApiErrorCode;
+import org.quizly.quizly.core.application.BaseResponse;
+import org.quizly.quizly.core.exception.error.GlobalErrorCode;
+import org.quizly.quizly.external.clova.dto.Response.Hcx007MockExamResponse;
+import org.quizly.quizly.external.clova.service.CreateMockExamClovaStudioService;
+import org.quizly.quizly.external.ocr.service.ClovaOcrService;
+import org.quizly.quizly.external.ocr.service.ExtractTextFromOcrService;
+import org.quizly.quizly.mock.dto.request.CreateMemberMockExamRequest;
+import org.quizly.quizly.mock.dto.response.CreateMemberMockExamResponse;
+import org.quizly.quizly.mock.service.CreateMemberMockExamService;
+import org.quizly.quizly.oauth.UserPrincipal;
+import org.quizly.quizly.quiz.service.CreateMemberQuizzesService;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+import java.util.Optional;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "Mock", description = "모의고사")
+public class CreateMemberOcrMockExamController {
+
+    private final ExtractTextFromOcrService extractTextFromOcrService;
+    private final CreateMemberMockExamService createMemberMockExamService;
+
+    @Operation(
+            summary = "OCR 기반 회원 모의고사 생성 API",
+            description = "회원 전용 API로 모의고사 문제를 생성 합니다.\n\n회원 API로 요청 시 토큰이 필요합니다.\n\n OCR 기반 모의고사 제작합니다.",
+            operationId = "/mock/member/ocr"
+    )
+    @PostMapping(value = "/mock/member/ocr", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @ApiErrorCode(errorCodes = {GlobalErrorCode.class, CreateMemberMockExamService.CreateMemberMockExamErrorCode.class})
+    public ResponseEntity<CreateMemberMockExamResponse> createOcrMemberMockExam(
+            @RequestParam("file") MultipartFile file,
+            @RequestParam("mockExamTypeList") List<CreateMemberMockExamRequest.MockExamType> mockExamTypeList,
+            @AuthenticationPrincipal UserPrincipal userPrincipal
+    ){
+        ClovaOcrService.ClovaOcrRequest ocrRequest = ClovaOcrService.ClovaOcrRequest.builder()
+                .file(file)
+                .build();
+
+        ClovaOcrService.ClovaOcrResponse ocrResponse = extractTextFromOcrService.execute(ocrRequest);
+        String plainText = ocrResponse.getPlainText();
+
+        if (ocrResponse == null || !ocrResponse.isSuccess()) {
+            if (ocrResponse != null && ocrResponse.getErrorCode() != null) {
+                throw ocrResponse.getErrorCode().toException();
+            }
+            throw GlobalErrorCode.INTERNAL_ERROR.toException();
+        }
+
+        CreateMemberMockExamService.CreateMemberMockExamResponse serviceResponse = createMemberMockExamService.execute(
+                CreateMemberMockExamService.CreateMemberMockExamRequest.builder()
+                        .plainText(plainText)
+                        .mockExamTypeList(mockExamTypeList)
+                        .userPrincipal(userPrincipal)
+                        .build());
+
+        if (serviceResponse == null || !serviceResponse.isSuccess()) {
+            if (serviceResponse != null && serviceResponse.getErrorCode() != null) {
+                throw serviceResponse.getErrorCode().toException();
+            }
+            throw GlobalErrorCode.INTERNAL_ERROR.toException();
+        }
+
+        return ResponseEntity.ok(toResponse(serviceResponse));
+    }
+
+
+    private CreateMemberMockExamResponse toResponse(CreateMemberMockExamService.CreateMemberMockExamResponse serviceResponse) {
+        List<Hcx007MockExamResponse> hcx007MockExamResponseList = serviceResponse.getQuizList();
+        List<CreateMemberMockExamResponse.MockExamDetail> mockExamDetailList =  hcx007MockExamResponseList.stream()
+                .map(mock -> new CreateMemberMockExamResponse.MockExamDetail(
+                        mock.getQuiz(),
+                        mock.getType().toString(),
+                        mock.getOptions(),
+                        mock.getAnswer(),
+                        mock.getExplanation()
+                )).toList();
+        return CreateMemberMockExamResponse.builder()
+                .mockExamDetailList(mockExamDetailList)
+                .build();
+    }
+}


### PR DESCRIPTION
- 연관 이슈  
  Closes #34

- 작업 사항  
  - OCR을 통해 이미지에서 텍스트를 추출한 뒤, 추출된 내용을 기반으로 회원 전용 모의고사를 생성하는 API를 추가했습니다.  
  - OCR 문제 생성과 마찬가지로 ExtractTextFromOcrService를 사용하여 Clova OCR 결과를 가공하고, CreateMemberMockExamService를 재활용하는 구조로 구현했습니다.  
  - 요청 형식은 multipart/form-data이며, file과 mockExamTypeList를 함께 받습니다.  
  - 기존 텍스트 기반 로직과 동일한 응답 구조(CreateMemberMockExamResponse)를 유지합니다.

- 테스트  
  - 파일 업로드 및 mockExamTypeList 파라미터 전달 테스트 완료했습니다.  
  - OCR 결과에서 plainText가 정상 추출되는지, 서비스 실행 후 모의고사 문제 리스트가 반환되는지 검증했습니다.
<img width="1693" height="1285" alt="image" src="https://github.com/user-attachments/assets/65ec03db-ed95-445c-9e04-b1ab9d408a18" />


- 이슈 사항
  - FIND_CORRECT, FIND_INCORRECT로 요청을 보낼 때 3-4분이 넘어가는 상황이 발생합니다. 다른 조합의 요청은 1-2분 내외인 것에 비해 조합에 따라 응답시간이 차이가 있다는 부분을 고려해야할 것 같습니다.
<img width="1665" height="1273" alt="image" src="https://github.com/user-attachments/assets/08094186-40bb-413c-95fb-e2b018b84149" />
  - 또한 간혹 FIND_CORRECT Type으로 인식되었음에도 불구하고 '옳지 않은 것'은 문제가 만들어지는 상황을 발견할 수 있는데, 이는 옳지 않은 것 중 옳은 것을 고르는 문제로 생성한 것으로 보입니다. 적은 비율로 발생하기 때문에 추후 통계적 검증이 필요한 부분으로 보입니다.

<img width="1678" height="1250" alt="image" src="https://github.com/user-attachments/assets/d7963832-e601-43d9-91ce-a3f5c2289f13" />
