### PR TITLE
feat(#37): 유저 닉네임 업데이트 api

### DIFF
--- a/src/main/java/org/quizly/quizly/account/controller/put/UpdateUserNickNameController.java
+++ b/src/main/java/org/quizly/quizly/account/controller/put/UpdateUserNickNameController.java
@@ -1,0 +1,59 @@
+package org.quizly.quizly.account.controller.put;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.quizly.quizly.account.dto.request.UpdateUserNickNameRequest;
+import org.quizly.quizly.account.dto.response.UpdateUserNickNameResponse;
+import org.quizly.quizly.account.service.UpdateUserNickNameService;
+import org.quizly.quizly.account.service.UpdateUserNickNameService.UpdateUserNickNameErrorCode;
+import org.quizly.quizly.configuration.swagger.ApiErrorCode;
+import org.quizly.quizly.core.application.BaseResponse;
+import org.quizly.quizly.core.exception.error.GlobalErrorCode;
+import org.quizly.quizly.oauth.UserPrincipal;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "Account", description = "계정")
+public class UpdateUserNickNameController {
+
+  private final UpdateUserNickNameService updateUserNickNameService;
+
+  @Operation(
+      summary = "유저 닉네임 변경 API",
+      description = "회원 전용 API로 현재 로그인 유저의 닉네임을 변경합니다.\n\n회원 API로 요청 시 토큰이 필요합니다.",
+      operationId = "/account/nickname"
+  )
+  @PutMapping("/account/nickname")
+  @ApiErrorCode(errorCodes = {GlobalErrorCode.class, UpdateUserNickNameErrorCode.class})
+  public ResponseEntity<UpdateUserNickNameResponse> updateUserNickName (
+      @RequestBody UpdateUserNickNameRequest request,
+      @AuthenticationPrincipal UserPrincipal userPrincipal
+  ) {
+
+    UpdateUserNickNameService.UpdateUserNickNameResponse serviceResponse = updateUserNickNameService.execute(
+        UpdateUserNickNameService.UpdateUserNickNameRequest.builder()
+            .nickName(request.getNickName())
+            .userPrincipal(userPrincipal)
+            .build());
+
+    if (serviceResponse == null || !serviceResponse.isSuccess()) {
+      Optional.ofNullable(serviceResponse)
+          .map(BaseResponse::getErrorCode)
+          .ifPresentOrElse(errorCode -> {
+            throw errorCode.toException();
+          }, () -> {
+            throw GlobalErrorCode.INTERNAL_ERROR.toException();
+          });
+    }
+
+    return ResponseEntity.ok(UpdateUserNickNameResponse.builder().build());
+  }
+
+}

--- a/src/main/java/org/quizly/quizly/account/dto/request/UpdateUserNickNameRequest.java
+++ b/src/main/java/org/quizly/quizly/account/dto/request/UpdateUserNickNameRequest.java
@@ -1,0 +1,27 @@
+package org.quizly.quizly.account.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.quizly.quizly.core.application.BaseRequest;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "유저 닉네임 변경 요청")
+public class UpdateUserNickNameRequest implements BaseRequest {
+
+  @Schema(description = "변경할 닉네임", example = "퀴즐리")
+  private String nickName;
+
+  @Override
+  public boolean isValid() {
+    return nickName != null && !nickName.isBlank();
+  }
+
+}

--- a/src/main/java/org/quizly/quizly/account/dto/response/UpdateUserNickNameResponse.java
+++ b/src/main/java/org/quizly/quizly/account/dto/response/UpdateUserNickNameResponse.java
@@ -1,0 +1,20 @@
+package org.quizly.quizly.account.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+import org.quizly.quizly.core.application.BaseResponse;
+import org.quizly.quizly.core.exception.error.GlobalErrorCode;
+
+@Getter
+@Setter
+@SuperBuilder
+@NoArgsConstructor
+@ToString
+@Schema(description = "유저 닉네임 변경 응답")
+public class UpdateUserNickNameResponse  extends BaseResponse<GlobalErrorCode> {
+
+}

--- a/src/main/java/org/quizly/quizly/account/service/UpdateUserNickNameService.java
+++ b/src/main/java/org/quizly/quizly/account/service/UpdateUserNickNameService.java
@@ -1,0 +1,132 @@
+package org.quizly.quizly.account.service;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+import lombok.extern.log4j.Log4j2;
+import org.quizly.quizly.account.service.UpdateUserNickNameService.UpdateUserNickNameRequest;
+import org.quizly.quizly.account.service.UpdateUserNickNameService.UpdateUserNickNameResponse;
+import org.quizly.quizly.core.application.BaseRequest;
+import org.quizly.quizly.core.application.BaseResponse;
+import org.quizly.quizly.core.application.BaseService;
+import org.quizly.quizly.core.domin.entity.User;
+import org.quizly.quizly.core.domin.repository.UserRepository;
+import org.quizly.quizly.core.exception.DomainException;
+import org.quizly.quizly.core.exception.error.BaseErrorCode;
+import org.quizly.quizly.oauth.UserPrincipal;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Log4j2
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class UpdateUserNickNameService implements BaseService<UpdateUserNickNameRequest, UpdateUserNickNameResponse> {
+
+  private final UserRepository userRepository;
+
+  @Override
+  public UpdateUserNickNameResponse execute(UpdateUserNickNameRequest request) {
+    if (request == null || !request.isValid()) {
+      return UpdateUserNickNameResponse.builder()
+          .success(false)
+          .errorCode(UpdateUserNickNameErrorCode.NOT_EXIST_REQUIRED_PARAMETER)
+          .build();
+    }
+
+    String providerId = request.getUserPrincipal().getProviderId();
+    if (providerId == null || providerId.isEmpty()) {
+      return UpdateUserNickNameResponse.builder()
+          .success(false)
+          .errorCode(UpdateUserNickNameErrorCode.NOT_EXIST_PROVIDER_ID)
+          .build();
+    }
+
+    User user = userRepository.findByProviderId(providerId);
+    if (user == null) {
+      log.error("[UpdateUserNickNameService] User not found for providerId: {}", providerId);
+      return UpdateUserNickNameResponse.builder()
+          .success(false)
+          .errorCode(UpdateUserNickNameErrorCode.NOT_FOUND_USER)
+          .build();
+    }
+
+    String newNickName = request.getNickName();
+    UpdateUserNickNameErrorCode validationError = validateNickName(newNickName);
+    if (validationError != null) {
+      log.warn("[UpdateUserNickNameService] Nickname validation failed: {}, error: {}", newNickName, validationError);
+      return UpdateUserNickNameResponse.builder()
+          .success(false)
+          .errorCode(validationError)
+          .build();
+    }
+
+    user.setNickName(newNickName);
+    return UpdateUserNickNameResponse.builder()
+        .success(true)
+        .build();
+  }
+
+  private UpdateUserNickNameErrorCode validateNickName(String nickName) {
+    if (nickName.length() < 2 || nickName.length() > 20) {
+      return UpdateUserNickNameErrorCode.INVALID_NICKNAME_LENGTH;
+    }
+
+    return null;
+  }
+
+  @Getter
+  @RequiredArgsConstructor
+  public enum UpdateUserNickNameErrorCode implements BaseErrorCode<DomainException> {
+
+    NOT_EXIST_REQUIRED_PARAMETER(HttpStatus.BAD_REQUEST, "요청 파라미터가 존재하지 않습니다."),
+    NOT_EXIST_PROVIDER_ID(HttpStatus.BAD_REQUEST, "Provider ID가 존재하지 않습니다."),
+    NOT_FOUND_USER(HttpStatus.NOT_FOUND, "유저를 찾을 수 없습니다."),
+    INVALID_NICKNAME_LENGTH(HttpStatus.BAD_REQUEST, "닉네임은 2자 이상 20자 이하여야 합니다.");
+
+    private final HttpStatus httpStatus;
+
+    private final String message;
+
+    @Override
+    public DomainException toException() {
+      return new DomainException(httpStatus, this);
+    }
+  }
+
+
+  @Getter
+  @Setter
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @ToString
+  public static class UpdateUserNickNameRequest implements BaseRequest {
+
+    private String nickName;
+
+    private UserPrincipal userPrincipal;
+
+    @Override
+    public boolean isValid() {
+      return nickName != null && !nickName.isBlank() && userPrincipal != null;
+    }
+  }
+
+  @Getter
+  @Setter
+  @SuperBuilder
+  @NoArgsConstructor
+  @ToString
+  public static class UpdateUserNickNameResponse extends
+      BaseResponse<UpdateUserNickNameErrorCode> {
+
+  }
+
+}

--- a/src/main/java/org/quizly/quizly/core/domin/entity/User.java
+++ b/src/main/java/org/quizly/quizly/core/domin/entity/User.java
@@ -56,6 +56,9 @@ public class User extends BaseEntity {
   private String name;
 
   @Column(nullable = false)
+  private String nickName;
+
+  @Column(nullable = false)
   private String email;
 
   @Enumerated(EnumType.STRING)

--- a/src/main/java/org/quizly/quizly/oauth/service/OAuth2LoginUserService.java
+++ b/src/main/java/org/quizly/quizly/oauth/service/OAuth2LoginUserService.java
@@ -74,6 +74,7 @@ public class OAuth2LoginUserService extends DefaultOAuth2UserService {
     userEntity.setProviderId(oAuth2UserInfo.getProviderId());
     userEntity.setEmail(oAuth2UserInfo.getEmail());
     userEntity.setName(oAuth2UserInfo.getName());
+    userEntity.setNickName(oAuth2UserInfo.getName());
     userEntity.setRole(Role.USER);
     userRepository.save(userEntity);
     return userEntity;


### PR DESCRIPTION
- 연관 이슈
이 PR이 해결하는 이슈: `Closes #37` (병합 시 자동으로 이슈 닫힘)

- 작업 사항
    - 마이페이지 기능 추가를 위한 기반 작업으로 사용자 엔티티에 닉네임 필드를 추가하고 로그인한 사용자 본인의 닉네임 변경 API를 구현
        - 도메인 명은 account 사용 ( 개발팀 회의 결정사항)
        - User 엔티티(테이블)에 닉네임(nickname) 필드를 추가했습니다.
        - PATCH /account/nickname 로그인한 사용자 본인의 닉네임을 변경할 수 있는 API 추가
    
- 테스트
    <img width="740" height="755" alt="image" src="https://github.com/user-attachments/assets/e5464e2a-6af0-4205-b052-224a7f462fa7" />
