### PR TITLE
feat(#45): 유저 정보 조회 api

### DIFF
--- a/src/main/java/org/quizly/quizly/account/controller/get/ReadUserInfoController.java
+++ b/src/main/java/org/quizly/quizly/account/controller/get/ReadUserInfoController.java
@@ -1,0 +1,61 @@
+package org.quizly.quizly.account.controller.get;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.quizly.quizly.account.dto.response.ReadUserInfoResponse;
+import org.quizly.quizly.account.service.ReadUserInfoService;
+import org.quizly.quizly.account.service.ReadUserInfoService.ReadUserInfoErrorCode;
+import org.quizly.quizly.account.service.ReadUserInfoService.ReadUserInfoRequest;
+import org.quizly.quizly.configuration.swagger.ApiErrorCode;
+import org.quizly.quizly.core.application.BaseResponse;
+import org.quizly.quizly.core.exception.error.GlobalErrorCode;
+import org.quizly.quizly.oauth.UserPrincipal;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "Account", description = "계정")
+public class ReadUserInfoController {
+
+  private final ReadUserInfoService readUserInfoService;
+
+  @Operation(
+      summary = "유저 정보 조회 API",
+      description = "현재 로그인 유저의 정보를 조회합니다.",
+      operationId = "/account"
+  )
+  @GetMapping("/account")
+  @ApiErrorCode(errorCodes = {GlobalErrorCode.class, ReadUserInfoErrorCode.class})
+  public ResponseEntity<ReadUserInfoResponse> readUserInfo(
+      @AuthenticationPrincipal UserPrincipal userPrincipal
+  ) {
+    ReadUserInfoService.ReadUserInfoResponse serviceResponse = readUserInfoService.execute(
+        ReadUserInfoRequest.builder()
+            .userPrincipal(userPrincipal)
+            .build()
+    );
+
+    if (serviceResponse == null) {
+      throw GlobalErrorCode.INTERNAL_ERROR.toException();
+    }
+    if (!serviceResponse.isSuccess()) {
+      throw serviceResponse.getErrorCode().toException();
+    }
+
+    return ResponseEntity.ok(toResponse(serviceResponse));
+  }
+
+  private ReadUserInfoResponse toResponse(ReadUserInfoService.ReadUserInfoResponse serviceResponse) {
+    return ReadUserInfoResponse.builder()
+        .name(serviceResponse.getName())
+        .nickName(serviceResponse.getNickName())
+        .email(serviceResponse.getEmail())
+        .profileImageUrl(serviceResponse.getProfileImageUrl())
+        .build();
+  }
+}

--- a/src/main/java/org/quizly/quizly/account/dto/response/ReadUserInfoResponse.java
+++ b/src/main/java/org/quizly/quizly/account/dto/response/ReadUserInfoResponse.java
@@ -1,0 +1,30 @@
+package org.quizly.quizly.account.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+import org.quizly.quizly.core.application.BaseResponse;
+import org.quizly.quizly.core.exception.error.GlobalErrorCode;
+
+@Getter
+@NoArgsConstructor
+@ToString
+@SuperBuilder
+@Schema(description = "유저 정보 조회 응답")
+public class ReadUserInfoResponse extends BaseResponse<GlobalErrorCode> {
+
+  @Schema(description = "이름", example = "퀴즐리")
+  private String name;
+
+  @Schema(description = "닉네임", example = "에스F레소")
+  private String nickName;
+
+  @Schema(description = "이메일", example = "quizlystudy@gmail.com")
+  private String email;
+
+  @Schema(description = "프로필 url", example = "https://kr.object.ncloudstorage.com/quizly-profile-images/defaults/default_profile.png")
+  private String profileImageUrl;
+
+}

--- a/src/main/java/org/quizly/quizly/account/service/ReadUserInfoService.java
+++ b/src/main/java/org/quizly/quizly/account/service/ReadUserInfoService.java
@@ -1,0 +1,114 @@
+package org.quizly.quizly.account.service;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+import lombok.extern.log4j.Log4j2;
+import org.quizly.quizly.account.service.ReadUserInfoService.ReadUserInfoRequest;
+import org.quizly.quizly.account.service.ReadUserInfoService.ReadUserInfoResponse;
+import org.quizly.quizly.core.application.BaseRequest;
+import org.quizly.quizly.core.application.BaseResponse;
+import org.quizly.quizly.core.application.BaseService;
+import org.quizly.quizly.core.domin.entity.User;
+import org.quizly.quizly.core.domin.repository.UserRepository;
+import org.quizly.quizly.core.exception.DomainException;
+import org.quizly.quizly.core.exception.error.BaseErrorCode;
+import org.quizly.quizly.oauth.UserPrincipal;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Log4j2
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ReadUserInfoService implements BaseService<ReadUserInfoRequest, ReadUserInfoResponse> {
+
+  private final UserRepository userRepository;
+
+  @Override
+  public ReadUserInfoResponse execute(ReadUserInfoRequest request) {
+    if (request == null || !request.isValid()) {
+      return ReadUserInfoResponse.builder()
+          .success(false)
+          .errorCode(ReadUserInfoErrorCode.NOT_EXIST_REQUIRED_PARAMETER)
+          .build();
+    }
+
+    String providerId = request.getUserPrincipal().getProviderId();
+    if (providerId == null || providerId.isBlank()) {
+      return ReadUserInfoResponse.builder()
+          .success(false)
+          .errorCode(ReadUserInfoErrorCode.NOT_EXIST_PROVIDER_ID)
+          .build();
+    }
+    User user = userRepository.findByProviderId(providerId);
+    if (user == null) {
+      log.error("[ReadUserInfoService] User not found for providerId: {}", providerId);
+      return ReadUserInfoResponse.builder()
+          .success(false)
+          .errorCode(ReadUserInfoErrorCode.NOT_FOUND_USER)
+          .build();
+    }
+
+    return ReadUserInfoResponse.builder()
+        .name(user.getName())
+        .nickName(user.getNickName())
+        .email(user.getEmail())
+        .profileImageUrl(user.getProfileImageUrl())
+        .success(true)
+        .build();
+  }
+
+  @Getter
+  @RequiredArgsConstructor
+  public enum ReadUserInfoErrorCode implements BaseErrorCode<DomainException> {
+
+    NOT_EXIST_REQUIRED_PARAMETER(HttpStatus.BAD_REQUEST, "요청 파라미터가 존재하지 않습니다."),
+    NOT_EXIST_PROVIDER_ID(HttpStatus.BAD_REQUEST, "Provider ID가 존재하지 않습니다."),
+    NOT_FOUND_USER(HttpStatus.NOT_FOUND, "유저를 찾을 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    @Override
+    public DomainException toException() {
+      return new DomainException(httpStatus, this);
+    }
+  }
+
+  @Getter
+  @Setter
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @ToString
+  public static class ReadUserInfoRequest implements BaseRequest {
+
+    private UserPrincipal userPrincipal;
+
+    @Override
+    public boolean isValid() {
+      return userPrincipal != null;
+    }
+  }
+
+  @Getter
+  @Setter
+  @SuperBuilder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @ToString
+  public static class ReadUserInfoResponse extends BaseResponse<ReadUserInfoErrorCode> {
+    private String name;
+    private String nickName;
+    private String email;
+    private String profileImageUrl;
+  }
+
+}


### PR DESCRIPTION
- 연관 이슈
이 PR이 해결하는 이슈: `Closes #45` (병합 시 자동으로 이슈 닫힘)

- 작업 사항
    - 마이페이지 계정 관리 기능을 위한 api 구현
    - 보안을 위해  유저의 모든 계정 정보를 반환하지 않고 필수적인 정보만 제공
        (이름, 닉네임, 이메일, 프로필 사진 링크) 
    
- 테스트
    <img width="1085" height="782" alt="스크린샷 2025-11-14 오전 10 11 27" src="https://github.com/user-attachments/assets/479815bf-285d-44c4-9095-66dba4e59bda" />

