### PR TITLE
feat(#47): 풀이 시간 기록 추가

### DIFF
--- a/src/main/java/org/quizly/quizly/core/domin/entity/SolveHistory.java
+++ b/src/main/java/org/quizly/quizly/core/domin/entity/SolveHistory.java
@@ -13,6 +13,8 @@ import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 import org.quizly.quizly.core.domin.shared.BaseEntity;
 
+import java.time.LocalDateTime;
+
 @Getter
 @Setter
 @NoArgsConstructor
@@ -35,4 +37,12 @@ public class SolveHistory extends BaseEntity {
 
   @Column(nullable = false)
   private String userAnswer;
+
+  @Column(nullable = false)
+  private Double solveTime;
+
+  @Column(nullable = false)
+  private LocalDateTime submittedAt;
+
+
 }

--- a/src/main/java/org/quizly/quizly/quiz/controller/post/GradeMemberQuizzesController.java
+++ b/src/main/java/org/quizly/quizly/quiz/controller/post/GradeMemberQuizzesController.java
@@ -45,6 +45,7 @@ public class GradeMemberQuizzesController {
         GradeMemberQuizzesRequest.builder()
             .quizId(quizId)
             .userAnswer(request.getUserAnswer())
+                .solveTime(request.getSolveTime())
             .userPrincipal(userPrincipal)
             .build()
     );

--- a/src/main/java/org/quizly/quizly/quiz/dto/request/GradeQuizzesRequest.java
+++ b/src/main/java/org/quizly/quizly/quiz/dto/request/GradeQuizzesRequest.java
@@ -19,8 +19,12 @@ public class GradeQuizzesRequest implements BaseRequest {
   @Schema(description = "사용자 답변 ", example = "대규모 릴리즈")
   private String userAnswer;
 
+  @Schema(description = "문제 풀이 시간(초 단위)", example = "8.3")
+  private Double solveTime;
+
   @Override
   public boolean isValid() {
-    return userAnswer != null && !userAnswer.isEmpty();
+    return userAnswer != null && !userAnswer.isEmpty()
+            && solveTime != null && solveTime >= 0;
   }
 }

--- a/src/main/java/org/quizly/quizly/quiz/service/GradeMemberQuizzesService.java
+++ b/src/main/java/org/quizly/quizly/quiz/service/GradeMemberQuizzesService.java
@@ -1,5 +1,6 @@
 package org.quizly.quizly.quiz.service;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -97,7 +98,7 @@ public class GradeMemberQuizzesService implements
     }
     boolean isCorrect = graderQuizResponse.isCorrect();
 
-    saveSolveHistory(user, quiz, request.getUserAnswer(), isCorrect);
+    saveSolveHistory(user, quiz, request.getUserAnswer(), isCorrect, request.getSolveTime());
 
     return GradeMemberQuizzesResponse.builder()
         .quiz(quiz)
@@ -105,15 +106,25 @@ public class GradeMemberQuizzesService implements
         .build();
   }
 
-  private void saveSolveHistory(User user, Quiz quiz, String userAnswer, boolean isCorrect) {
+  private void saveSolveHistory(
+          User user,
+          Quiz quiz,
+          String userAnswer,
+          boolean isCorrect,
+          Double solveTime
+  ) {
     SolveHistory solveHistory = SolveHistory.builder()
-        .user(user)
-        .quiz(quiz)
-        .isCorrect(isCorrect)
-        .userAnswer(userAnswer)
-        .build();
+            .user(user)
+            .quiz(quiz)
+            .isCorrect(isCorrect)
+            .userAnswer(userAnswer)
+            .solveTime(solveTime)
+            .submittedAt(LocalDateTime.now())
+            .build();
+
     solveHistoryRepository.save(solveHistory);
   }
+
 
   @Getter
   @RequiredArgsConstructor
@@ -150,9 +161,11 @@ public class GradeMemberQuizzesService implements
 
     private UserPrincipal userPrincipal;
 
+    private Double solveTime;
+
     @Override
     public boolean isValid() {
-      return quizId != null && userAnswer != null && userPrincipal != null;
+      return quizId != null && userAnswer != null && userPrincipal != null && solveTime != null && solveTime >= 0;
     }
   }
 


### PR DESCRIPTION
- 연관 이슈
   이 PR이 해결하는 이슈: Closes #47 (병합 시 자동으로 이슈 닫힘)

- 작업 사항
   - 문제 풀이 시간을 기록하고 통계적인 수치를 추후 대시보드에서 표현하기 위해 데이터 추가 작업을 진행했습니다.
   - 문제 풀이 시간을 기록할 때 start 시간을 저장하지 않고 solveTime(소요시간)만 받는 방식을 선택했습니다.
       - 이유?
              - solveTime이 프론트 측에서 가장 안정적으로 수집 가능한 값이고, 통계 분석에 더 정확한 값이라고 판단했기 때문. 
              - 사용자가 새로 고침하거나 화면을 이동하는 등 다양한 상황에서 start 시각은 불안정해지지만 solveTime은 UI단에서 일관적으로 측정이 가능하여 실제 풀이 시간 통계에 더 적합하다고 판단.
              - 또한 제출 시각(submittedAt)를 추가로 백엔드에서 기록함으로써 '어느 시간대에 풀이를 했는지'에 대한 시간대 통계를 충분히 만들 수 있고, 필요하다면 submittedAt에서 solveTime의 차를 계산하여 시작 시간 또한 알 수 있음.
              - 현재로서 시작시각이 분석에 큰 수요를 가져다주지 않을 것으로 판단.

- 테스트
<img width="1760" height="1000" alt="image" src="https://github.com/user-attachments/assets/91aa546e-350c-47d0-98ef-ede9738eb831" />

<img width="1366" height="50" alt="image" src="https://github.com/user-attachments/assets/eec3b9f5-5ce3-4bfc-a063-d37dd6f6f5a5" />
