### PR TITLE
refactor(#53): findByProviderId 메서드 Optional 반환 타입으로 변경

### DIFF
--- a/src/main/java/org/quizly/quizly/account/service/ReadUserInfoService.java
+++ b/src/main/java/org/quizly/quizly/account/service/ReadUserInfoService.java
@@ -1,5 +1,6 @@
 package org.quizly.quizly.account.service;
 
+import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -47,14 +48,15 @@ public class ReadUserInfoService implements BaseService<ReadUserInfoRequest, Rea
           .errorCode(ReadUserInfoErrorCode.NOT_EXIST_PROVIDER_ID)
           .build();
     }
-    User user = userRepository.findByProviderId(providerId);
-    if (user == null) {
+    Optional<User> userOptional = userRepository.findByProviderId(providerId);
+    if (userOptional.isEmpty()) {
       log.error("[ReadUserInfoService] User not found for providerId: {}", providerId);
       return ReadUserInfoResponse.builder()
           .success(false)
           .errorCode(ReadUserInfoErrorCode.NOT_FOUND_USER)
           .build();
     }
+    User user = userOptional.get();
 
     return ReadUserInfoResponse.builder()
         .name(user.getName())

--- a/src/main/java/org/quizly/quizly/account/service/UpdateUserNickNameService.java
+++ b/src/main/java/org/quizly/quizly/account/service/UpdateUserNickNameService.java
@@ -1,5 +1,6 @@
 package org.quizly.quizly.account.service;
 
+import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -48,14 +49,15 @@ public class UpdateUserNickNameService implements BaseService<UpdateUserNickName
           .build();
     }
 
-    User user = userRepository.findByProviderId(providerId);
-    if (user == null) {
+    Optional<User> userOptional = userRepository.findByProviderId(providerId);
+    if (userOptional.isEmpty()) {
       log.error("[UpdateUserNickNameService] User not found for providerId: {}", providerId);
       return UpdateUserNickNameResponse.builder()
           .success(false)
           .errorCode(UpdateUserNickNameErrorCode.NOT_FOUND_USER)
           .build();
     }
+    User user = userOptional.get();
 
     String newNickName = request.getNickName();
     UpdateUserNickNameErrorCode validationError = validateNickName(newNickName);

--- a/src/main/java/org/quizly/quizly/account/service/UpdateUserProfileImageService.java
+++ b/src/main/java/org/quizly/quizly/account/service/UpdateUserProfileImageService.java
@@ -1,5 +1,6 @@
 package org.quizly.quizly.account.service;
 
+import java.util.Optional;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 import lombok.extern.log4j.Log4j2;
@@ -45,14 +46,15 @@ public class UpdateUserProfileImageService implements BaseService<
                     .errorCode(UpdateUserProfileImageErrorCode.NOT_EXIST_PROVIDER_ID)
                     .build();
         }
-        User user = userRepository.findByProviderId(providerId);
-        if (user == null) {
+        Optional<User> userOptional = userRepository.findByProviderId(providerId);
+        if (userOptional.isEmpty()) {
             log.error("[UpdateUserProfileImageService] User not found for providerId: {}", providerId);
             return UpdateUserProfileImageResponse.builder()
                     .success(false)
                     .errorCode(UpdateUserProfileImageErrorCode.NOT_FOUND_USER)
                     .build();
         }
+        User user = userOptional.get();
 
         try {
             ProfileImageService.UploadProfileImageRequest uploadRequest =

--- a/src/main/java/org/quizly/quizly/core/domin/repository/RefreshTokenRepository.java
+++ b/src/main/java/org/quizly/quizly/core/domin/repository/RefreshTokenRepository.java
@@ -1,9 +1,10 @@
 package org.quizly.quizly.core.domin.repository;
 
+import java.util.Optional;
 import org.quizly.quizly.core.domin.entity.RefreshToken;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
 
-  RefreshToken findByProviderId(String providerId);
+  Optional<RefreshToken> findByProviderId(String providerId);
 }

--- a/src/main/java/org/quizly/quizly/core/domin/repository/UserRepository.java
+++ b/src/main/java/org/quizly/quizly/core/domin/repository/UserRepository.java
@@ -1,9 +1,10 @@
 package org.quizly.quizly.core.domin.repository;
 
+import java.util.Optional;
 import org.quizly.quizly.core.domin.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
-  User findByProviderId(String providerId);
+  Optional<User> findByProviderId(String providerId);
 }

--- a/src/main/java/org/quizly/quizly/oauth/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/org/quizly/quizly/oauth/OAuth2LoginSuccessHandler.java
@@ -8,6 +8,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.quizly.quizly.core.domin.entity.RefreshToken;
 import org.quizly.quizly.core.domin.repository.RefreshTokenRepository;
@@ -51,9 +52,9 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
     String accessToken = jwtProvider.generateAccessToken(providerId, role);
     String refreshToken = jwtProvider.generateRefreshToken(providerId);
 
-    RefreshToken refreshTokenEntity = refreshTokenRepository.findByProviderId(providerId);
-    if (refreshTokenEntity != null) {
-      refreshTokenEntity.setToken(refreshToken);
+    Optional<RefreshToken> refreshTokenOptional = refreshTokenRepository.findByProviderId(providerId);
+    if (refreshTokenOptional.isPresent()) {
+      refreshTokenOptional.get().setToken(refreshToken);
     } else {
       refreshTokenRepository.save(new RefreshToken(providerId, customUserDetails.getName(), refreshToken));
     }

--- a/src/main/java/org/quizly/quizly/oauth/service/OAuth2LoginUserService.java
+++ b/src/main/java/org/quizly/quizly/oauth/service/OAuth2LoginUserService.java
@@ -1,5 +1,6 @@
 package org.quizly.quizly.oauth.service;
 
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.quizly.quizly.core.domin.entity.User;
@@ -52,13 +53,11 @@ public class OAuth2LoginUserService extends DefaultOAuth2UserService {
   }
 
   private User processUser(OAuth2UserInfo oAuth2UserInfo) {
-    User existData = userRepository.findByProviderId(oAuth2UserInfo.getProviderId());
+    Optional<User> existDataOptional = userRepository.findByProviderId(oAuth2UserInfo.getProviderId());
 
-    if (existData == null) {
-      return createUser(oAuth2UserInfo);
-    }
+    return existDataOptional.map(user -> updateUser(user, oAuth2UserInfo))
+        .orElseGet(() -> createUser(oAuth2UserInfo));
 
-    return updateUser(existData, oAuth2UserInfo);
   }
 
   private User createUser(OAuth2UserInfo oAuth2UserInfo) {

--- a/src/main/java/org/quizly/quizly/quiz/service/CreateMemberQuizzesService.java
+++ b/src/main/java/org/quizly/quizly/quiz/service/CreateMemberQuizzesService.java
@@ -1,6 +1,7 @@
 package org.quizly.quizly.quiz.service;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
@@ -65,14 +66,16 @@ public class CreateMemberQuizzesService implements BaseService<CreateMemberQuizz
           .errorCode(CreateMemberQuizzesErrorCode.NOT_EXIST_PROVIDER_ID)
           .build();
     }
-    User user = userRepository.findByProviderId(providerId);
-    if (user == null) {
+
+    Optional<User> userOptional = userRepository.findByProviderId(providerId);
+    if (userOptional.isEmpty()) {
       log.error("[CreateMemberQuizzesService] User not found for providerId: {}", providerId);
       return CreateMemberQuizzesResponse.builder()
           .success(false)
           .errorCode(CreateMemberQuizzesErrorCode.NOT_FOUND_USER)
           .build();
     }
+    User user = userOptional.get();
 
     CreateTopicResponse createTopicResponse = createTopicService.execute(
         CreateTopicRequest.builder()

--- a/src/main/java/org/quizly/quizly/quiz/service/GradeMemberQuizzesService.java
+++ b/src/main/java/org/quizly/quizly/quiz/service/GradeMemberQuizzesService.java
@@ -59,14 +59,15 @@ public class GradeMemberQuizzesService implements
           .errorCode(GradeMemberQuizzesErrorCode.NOT_EXIST_PROVIDER_ID)
           .build();
     }
-    User user = userRepository.findByProviderId(providerId);
-    if (user == null) {
+    Optional<User> userOptional = userRepository.findByProviderId(providerId);
+    if (userOptional.isEmpty()) {
       log.error("[GradeMemberQuizzesService] User not found for providerId: {}", providerId);
       return GradeMemberQuizzesResponse.builder()
           .success(false)
           .errorCode(GradeMemberQuizzesErrorCode.NOT_FOUND_USER)
           .build();
     }
+    User user = userOptional.get();
 
     Optional<Quiz> optionalQuiz = quizRepository.findById(request.getQuizId());
     if (optionalQuiz.isEmpty()) {

--- a/src/main/java/org/quizly/quizly/quiz/service/ReadQuizzesService.java
+++ b/src/main/java/org/quizly/quizly/quiz/service/ReadQuizzesService.java
@@ -2,6 +2,7 @@ package org.quizly.quizly.quiz.service;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -53,14 +54,15 @@ public class ReadQuizzesService implements BaseService<ReadQuizzesRequest, ReadQ
           .errorCode(ReadQuizzesErrorCode.NOT_EXIST_PROVIDER_ID)
           .build();
     }
-    User user = userRepository.findByProviderId(providerId);
-    if (user == null) {
+    Optional<User> userOptional = userRepository.findByProviderId(providerId);
+    if (userOptional.isEmpty()) {
       log.error("[ReadQuizzesService] User not found for providerId: {}", providerId);
       return ReadQuizzesResponse.builder()
           .success(false)
           .errorCode(ReadQuizzesErrorCode.NOT_FOUND_USER)
           .build();
     }
+    User user = userOptional.get();
 
     List<Quiz> quizList = quizRepository.findAllByUserWithOptions(user);
     if (quizList.isEmpty()) {

--- a/src/main/java/org/quizly/quizly/quiz/service/ReadWrongQuizzesService.java
+++ b/src/main/java/org/quizly/quizly/quiz/service/ReadWrongQuizzesService.java
@@ -1,6 +1,7 @@
 package org.quizly.quizly.quiz.service;
 
 import java.util.List;
+import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -50,14 +51,15 @@ public class ReadWrongQuizzesService implements BaseService<ReadWrongQuizzesRequ
           .errorCode(ReadWrongQuizzesErrorCode.NOT_EXIST_PROVIDER_ID)
           .build();
     }
-    User user = userRepository.findByProviderId(providerId);
-    if (user == null) {
+    Optional<User> userOptional = userRepository.findByProviderId(providerId);
+    if (userOptional.isEmpty()) {
       log.error("[ReadWrongQuizzesService] User not found for providerId: {}", providerId);
       return ReadWrongQuizzesResponse.builder()
           .success(false)
           .errorCode(ReadWrongQuizzesErrorCode.NOT_FOUND_USER)
           .build();
     }
+    User user = userOptional.get();
 
     List<SolveHistory> wrongSolveHistoryList = solveHistoryRepository.findLatestWrongSolveHistoriesByUser(user);
 

--- a/src/main/java/org/quizly/quizly/quiz/service/UpdateQuizzesTopicService.java
+++ b/src/main/java/org/quizly/quizly/quiz/service/UpdateQuizzesTopicService.java
@@ -1,6 +1,7 @@
 package org.quizly.quizly.quiz.service;
 
 import java.util.List;
+import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -53,14 +54,15 @@ public class UpdateQuizzesTopicService implements
           .errorCode(UpdateQuizzesTopicErrorCode.NOT_EXIST_PROVIDER_ID)
           .build();
     }
-    User user = userRepository.findByProviderId(providerId);
-    if (user == null) {
+    Optional<User> userOptional = userRepository.findByProviderId(providerId);
+    if (userOptional.isEmpty()) {
       log.error("[UpdateQuizzesTopicService] User not found for providerId: {}", providerId);
       return UpdateQuizzesTopicResponse.builder()
           .success(false)
           .errorCode(UpdateQuizzesTopicErrorCode.NOT_FOUND_USER)
           .build();
     }
+    User user = userOptional.get();
 
     List<Quiz> quizList = quizRepository.findAllById(request.getQuizIdList());
 


### PR DESCRIPTION
- 연관 이슈
이 PR이 해결하는 이슈: `Closes #53` (병합 시 자동으로 이슈 닫힘)

- 작업 사항 
    - UserRepository.findByProviderId()를 Optional<User> 반환 타입으로 변경
    - RefreshTokenRepository.findByProviderId()를 Optional<RefreshToken> 반환 타입으로 변경
    - NullPointerException 방지 및 코드 안전성 향상
        - 해당 PR 이후 Optional 체크하거나 처리하도록 강제하여 안정성 증가
        -  컴파일 타임 안전성 증가

- 영향 코드 (API)
    - GET /api/account/info
    - PUT /api/account/nickname
    - PUT /api/account/profile-image
    - POST /api/quiz/member
    - POST /api/quiz/grade
    - GET /api/quiz
    - GET /api/quiz/wrong
    - PUT /api/quiz/topic
    - POST /oauth2/authorization/{provider}
    - /login/oauth2/code/{provider}
    - POST /api/auth/reissue
