### PR TITLE
feat(#57): 모의고사 생성 API 문제 개수 선택 기능 및 범위 검증 추가

### DIFF
--- a/src/main/java/org/quizly/quizly/mock/controller/post/CreateMemberMockExamController.java
+++ b/src/main/java/org/quizly/quizly/mock/controller/post/CreateMemberMockExamController.java
@@ -44,6 +44,7 @@ public class CreateMemberMockExamController {
           .plainText(request.getPlainText())
           .mockExamTypeList(request.getMockExamTypeList())
           .userPrincipal(userPrincipal)
+          .quizCount(request.getQuizCount())
           .build());
 
     if (serviceResponse == null || !serviceResponse.isSuccess()) {

--- a/src/main/java/org/quizly/quizly/mock/controller/post/CreateMemberOcrMockExamController.java
+++ b/src/main/java/org/quizly/quizly/mock/controller/post/CreateMemberOcrMockExamController.java
@@ -4,17 +4,14 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.quizly.quizly.configuration.swagger.ApiErrorCode;
-import org.quizly.quizly.core.application.BaseResponse;
 import org.quizly.quizly.core.exception.error.GlobalErrorCode;
 import org.quizly.quizly.external.clova.dto.Response.Hcx007MockExamResponse;
-import org.quizly.quizly.external.clova.service.CreateMockExamClovaStudioService;
 import org.quizly.quizly.external.ocr.service.ClovaOcrService;
 import org.quizly.quizly.external.ocr.service.ExtractTextFromOcrService;
 import org.quizly.quizly.mock.dto.request.CreateMemberMockExamRequest;
 import org.quizly.quizly.mock.dto.response.CreateMemberMockExamResponse;
 import org.quizly.quizly.mock.service.CreateMemberMockExamService;
 import org.quizly.quizly.oauth.UserPrincipal;
-import org.quizly.quizly.quiz.service.CreateMemberQuizzesService;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -44,6 +41,7 @@ public class CreateMemberOcrMockExamController {
     public ResponseEntity<CreateMemberMockExamResponse> createOcrMemberMockExam(
             @RequestParam("file") MultipartFile file,
             @RequestParam("mockExamTypeList") List<CreateMemberMockExamRequest.MockExamType> mockExamTypeList,
+            @RequestParam(value = "quizCount", required = false) Integer quizCount,
             @AuthenticationPrincipal UserPrincipal userPrincipal
     ){
         ClovaOcrService.ClovaOcrRequest ocrRequest = ClovaOcrService.ClovaOcrRequest.builder()
@@ -65,6 +63,7 @@ public class CreateMemberOcrMockExamController {
                         .plainText(plainText)
                         .mockExamTypeList(mockExamTypeList)
                         .userPrincipal(userPrincipal)
+                        .quizCount(quizCount)
                         .build());
 
         if (serviceResponse == null || !serviceResponse.isSuccess()) {

--- a/src/main/java/org/quizly/quizly/mock/dto/request/CreateMemberMockExamRequest.java
+++ b/src/main/java/org/quizly/quizly/mock/dto/request/CreateMemberMockExamRequest.java
@@ -40,6 +40,9 @@ public class CreateMemberMockExamRequest implements BaseRequest {
   @Schema(description = "모의고사 유형 목록", example = "[\"FIND_MATCH\", \"ESSAY\"]")
   private List<MockExamType> mockExamTypeList;
 
+  @Schema(description = "모의고사 문제 개수 (기본값: 20, 범위: 10~30)", nullable = true, example = "20")
+  private Integer quizCount;
+
   @Override
   public boolean isValid() {
     return plainText != null && mockExamTypeList != null && !mockExamTypeList.isEmpty();


### PR DESCRIPTION
- 연관 이슈
    - 이 PR이 해결하는 이슈: Closes #57  (병합 시 자동으로 이슈 닫힘)

- 작업 사항
    - 사용자가 모의고사 생성 시 원하는 문제 개수를 선택할 수 있는 기능 추가
        -> `quizCount`를 nullable 선언하여 기존 API 호출 코드에서 해당 파라미터를 제공하지 않아도 기본값 20문제 반환 (기능 추가에 따른 백엔드 선배포 PR)
    - 문제 개수 범위 검증 로직 추가 (10개~30개)
        -> 문제 개수에 대한 범위 검증을 추가하여 무분별한 문제 생성 방지
        -> 과도한 문제 생성으로 인한 AI 생성 비용 관리 및 서버 리소스 보호

- 테스트
    - 정상 범위(10-30개) 요청 시 정상 동작 확인
    - 문제 개수 10개 미만 요청 or 30개 초과 요청 시 에러 반환 확인
    - 문제 개수 누락시 20문제 반환 확인
