### PR TITLE
feat(#60): 개발 서버 배포 환경 세팅

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
+	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/org/quizly/quizly/configuration/CorsMvcConfig.java
+++ b/src/main/java/org/quizly/quizly/configuration/CorsMvcConfig.java
@@ -1,6 +1,8 @@
 package org.quizly.quizly.configuration;
 
 import java.util.List;
+
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.cors.CorsConfiguration;
@@ -10,10 +12,14 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 @Configuration
 public class CorsMvcConfig {
 
+  @Value("${custom.oauth2.front-redirect-url}")
+  private String frontRedirectUrl;
+
+
   @Bean
   public CorsConfigurationSource corsConfigurationSource() {
     CorsConfiguration configuration = new CorsConfiguration();
-    configuration.setAllowedOrigins(List.of("http://localhost:3000"));
+    configuration.setAllowedOrigins(List.of("http://localhost:5173",frontRedirectUrl));
     configuration.setAllowedMethods(List.of("*"));
     configuration.setAllowedHeaders(List.of("*"));
     configuration.setAllowCredentials(true);

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,90 @@
+server:
+  name: Quizly
+
+spring:
+  datasource:
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+  servlet:
+    multipart:
+      maxFileSize: 50MB # 파일 하나의 최대 크기
+      maxRequestSize: 50MB  # 한 번에 최대 업로드 가능 용량
+  security:
+    oauth2:
+      client:
+        registration:
+          naver:
+            client-name: naver
+            client-id: ${NAVER_CLIENT_ID}
+            client-secret: ${NAVER_CLIENT_SECRET}
+            redirect-uri: ${NAVER_REDIRECT_URI}
+            authorization-grant-type: authorization_code
+            scope:
+              - name
+              - email
+          kakao:
+            client-name: kakao
+            client-id: ${KAKAO_CLIENT_ID}
+            redirect-uri: ${KAKAO_REDIRECT_URI}
+            authorization-grant-type: authorization_code
+            scope: profile_nickname, account_email
+        provider:
+          naver:
+            authorization-uri: https://nid.naver.com/oauth2.0/authorize
+            token-uri: https://nid.naver.com/oauth2.0/token
+            user-info-uri: https://openapi.naver.com/v1/nid/me
+            user-name-attribute: response
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
+
+swagger:
+  enabled: true
+
+springdoc:
+  api-docs:
+    path: ${SPRING_PATH}
+  default-consumes-media-type: application/json
+  default-produces-media-type: application/json
+  version: 0.1
+  swagger-ui:
+    path: ${SWAGGER_PATH}
+    defaultModelsExpandDepth: 3
+    default-model-expand-depth: 3
+
+clova:
+  hcx007:
+    url: https://clovastudio.stream.ntruss.com/v3/chat-completions/HCX-007
+    key: ${CLOVA_KEY}
+
+ocr:
+  api:
+    url: https://l3vgawapd7.apigw.ntruss.com/custom/v1/45109/102c2f4dc7f9cfc6c16118f779239c1f9a3431cd033686ef7370c17cc1606dd3/general
+    secret: ${OCR_SECRET}
+
+jwt:
+  secret: ${JWT_SECRET}
+  access-token-expiration: ${JWT_ACCESS_TOKEN_EXPIRATION}
+  refresh-token-expiration: ${JWT_REFRESH_TOKEN_EXPIRATION}
+
+object-storage:
+  bucket: ${OBJECT_BUCKET}
+  endpoint: https://kr.object.ncloudstorage.com
+  region: ap-northeast-2
+  credentials:
+    access-key: ${NCP_OBJECT_ACCESS_KEY}
+    secret-key: ${NCP_OBJECT_SECRET_KEY}
+
+custom:
+  oauth2:
+    front-redirect-url: ${FRONT_REDIRECT_URL}


### PR DESCRIPTION
- 연관 이슈

  - 이 PR이 해결하는 이슈: #60  (병합 시 자동으로 이슈 닫힘)
- 작업 사항
  - QA를 위한 개발 서버 배포 환경 세팅 수정
  - application-dev.yml 도입하여 환경변수 별도 관리
  - 개발 서버의 경우 클라우드 타입의 제공 db 한계로 인해 mysql->mariaDB로 변경(의존성 수정)
  - CORS 설정 -> frontRedirectUrl 환경변수 이용하여 주입 
 
- 논의 이슈
  - 병합 이후 yml secret 수정 필요

- 테스트
  - 해당 브랜치에서 배포 작업 테스트 완료
  - 로그인 및 기타 API 요청 응답 확인
  - DB 데이터 들어가는 것 확인
  - 소셜 로그인 및 기타 API 프론트와의 동작 확인