### PR TITLE
fix(#58): 비정상 청크 병합으로 불완전 JSON 응답 방지

### DIFF
--- a/src/main/java/org/quizly/quizly/quiz/service/CreateGuestQuizzesService.java
+++ b/src/main/java/org/quizly/quizly/quiz/service/CreateGuestQuizzesService.java
@@ -39,8 +39,8 @@ public class CreateGuestQuizzesService implements BaseService<CreateGuestQuizzes
   private final QuizRepository quizRepository;
 
   private static final int DEFAULT_QUIZ_COUNT = 3;
-  private static final int DEFAULT_QUIZ_BATCH_SIZE = 3;
-  private static final int DEFAULT_CHUNK_SIZE = 1000;
+  private static final int DEFAULT_QUIZ_BATCH_SIZE = 2;
+  private static final int DEFAULT_CHUNK_SIZE = 500;
   private static final int DEFAULT_CHUNK_OVERLAP = 100;
   private static final String GUEST_TOPIC = "guest";
 

--- a/src/main/java/org/quizly/quizly/quiz/service/CreateMemberQuizzesService.java
+++ b/src/main/java/org/quizly/quizly/quiz/service/CreateMemberQuizzesService.java
@@ -46,8 +46,8 @@ public class CreateMemberQuizzesService implements BaseService<CreateMemberQuizz
   private final UserRepository userRepository;
 
   private static final int DEFAULT_QUIZ_COUNT = 10;
-  private static final int DEFAULT_QUIZ_BATCH_SIZE = 3;
-  private static final int DEFAULT_CHUNK_SIZE = 1000;
+  private static final int DEFAULT_QUIZ_BATCH_SIZE = 2;
+  private static final int DEFAULT_CHUNK_SIZE = 500;
   private static final int DEFAULT_CHUNK_OVERLAP = 100;
 
   @Override


### PR DESCRIPTION
- 연관 이슈
    - 이 PR이 해결하는 이슈: Closes #58 (병합 시 자동으로 이슈 닫힘)

- 작업 사항
    1. 청크 사이즈 축소: 1000, 700 → 500
        -> 사용자 입력이 소량일 경우 동일한 청크가 반복 사용되어 발생하는 중복 주제/문제 생성 가능성 감소
        -> 중복 주제 생성 빈도 감소 + 입력 텍스트 요구량 감소
    3. 마지막 청크 병합 로직 추가
        -> 200자 이하 짧은 마지막 청크로 인해 AI가 불완전한 JSON 생성 문제 해결
        -> 200자 이하 마지막 청크를 이전 청크와 자동 병합

- 추가 논의 사항
    - 입력창에서 최소 길이 안내 메시지 또는 경고 표시 기획 논의 필요
        -> 입력 자체가 500자 미만 입력 시 문제 제작에 오류 발생
        -> 입력이 충분하지 못한 상태에서 많은 문제 제작시 오류 발생

- 테스트
    - 기존 문제 케이스(약 1420자) 정상 동작 확인
