### PR TITLE
feat(#66): 모의고사 생성 API 문제 수 자동 결정 로직 도입

### DIFF
--- a/src/main/java/org/quizly/quizly/mock/controller/post/CreateMemberMockExamController.java
+++ b/src/main/java/org/quizly/quizly/mock/controller/post/CreateMemberMockExamController.java
@@ -44,7 +44,6 @@ public class CreateMemberMockExamController {
           .plainText(request.getPlainText())
           .mockExamTypeList(request.getMockExamTypeList())
           .userPrincipal(userPrincipal)
-          .quizCount(request.getQuizCount())
           .build());
 
     if (serviceResponse == null || !serviceResponse.isSuccess()) {

--- a/src/main/java/org/quizly/quizly/mock/controller/post/CreateMemberOcrMockExamController.java
+++ b/src/main/java/org/quizly/quizly/mock/controller/post/CreateMemberOcrMockExamController.java
@@ -41,7 +41,6 @@ public class CreateMemberOcrMockExamController {
     public ResponseEntity<CreateMemberMockExamResponse> createOcrMemberMockExam(
             @RequestParam("file") MultipartFile file,
             @RequestParam("mockExamTypeList") List<CreateMemberMockExamRequest.MockExamType> mockExamTypeList,
-            @RequestParam(value = "quizCount", required = false) Integer quizCount,
             @AuthenticationPrincipal UserPrincipal userPrincipal
     ){
         ClovaOcrService.ClovaOcrRequest ocrRequest = ClovaOcrService.ClovaOcrRequest.builder()
@@ -63,7 +62,6 @@ public class CreateMemberOcrMockExamController {
                         .plainText(plainText)
                         .mockExamTypeList(mockExamTypeList)
                         .userPrincipal(userPrincipal)
-                        .quizCount(quizCount)
                         .build());
 
         if (serviceResponse == null || !serviceResponse.isSuccess()) {

--- a/src/main/java/org/quizly/quizly/mock/dto/request/CreateMemberMockExamRequest.java
+++ b/src/main/java/org/quizly/quizly/mock/dto/request/CreateMemberMockExamRequest.java
@@ -40,9 +40,6 @@ public class CreateMemberMockExamRequest implements BaseRequest {
   @Schema(description = "모의고사 유형 목록", example = "[\"FIND_MATCH\", \"ESSAY\"]")
   private List<MockExamType> mockExamTypeList;
 
-  @Schema(description = "모의고사 문제 개수 (기본값: 20, 범위: 10~30)", nullable = true, example = "20")
-  private Integer quizCount;
-
   @Override
   public boolean isValid() {
     return plainText != null && mockExamTypeList != null && !mockExamTypeList.isEmpty();


### PR DESCRIPTION
- 연관 이슈
    - 이 PR이 해결하는 이슈: close #66 (병합 시 자동으로 이슈 닫힘)

- 작업 사항
    - 사용자가 문제 개수를 직접 선택하던 기존 방식을 제거하고, 입력 텍스트 길이에 따라 시스템이 자동으로 문제 수를 결정하도록 개선
    - 청크(`Chunk`) 단위로 생성 가능한 문제 수를 계산하여 자동 결정
        -  문제 수 = 청크 개수 × 2 (`DEFAULT_MOCK_EXAM_BATCH_SIZE`)
        -  최소 10문제, 최대 30문제 범위 보장

- 테스트
    - 짧은 텍스트(~2,500자) 입력 시 최소 10문제 생성 확인
        -> 극단적으로 짧은 경우 동일한 문제 제작 (프론트에서 제한 필요)
    - 긴 텍스트(7,500자 이상) 입력 시 최대 30문제 생성 확인

