### PR TITLE
feat(#71): 누적 학습 통계 조회 API (대시보드)

### DIFF
--- a/src/main/java/org/quizly/quizly/account/controller/get/ReadDashboardController.java
+++ b/src/main/java/org/quizly/quizly/account/controller/get/ReadDashboardController.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.quizly.quizly.account.dto.response.ReadDashboardResponse;
+import org.quizly.quizly.account.dto.response.ReadDashboardResponse.CumulativeSummary;
 import org.quizly.quizly.account.dto.response.ReadDashboardResponse.QuizTypeSummary;
 import org.quizly.quizly.account.service.ReadDashboardService;
 import org.quizly.quizly.account.service.ReadDashboardService.ReadDashboardErrorCode;
@@ -31,6 +32,7 @@ public class ReadDashboardController {
   @Operation(
       summary = "마이페이지 대시보드 조회 API",
       description = "현재 로그인 유저의 학습 통계 대시보드 정보를 조회합니다.\n\n"
+          + "- 이번 달 누적 학습 통계: 총 풀이 수, 정답 수, 오답 수(이번 달 1일 ~ 오늘)\n"
           + "- 문제 유형별 통계: 각 유형별 풀이 수, 정답 수, 오답 수(이번 달 1일 ~ 오늘)\n",
       operationId = "/account/dashboard"
   )
@@ -59,6 +61,12 @@ public class ReadDashboardController {
   }
 
   private ReadDashboardResponse toResponse(ReadDashboardService.ReadDashboardServiceResponse serviceResponse) {
+    CumulativeSummary cumulativeSummary = new CumulativeSummary(
+        serviceResponse.getCumulativeSummary().solvedCount(),
+        serviceResponse.getCumulativeSummary().correctCount(),
+        serviceResponse.getCumulativeSummary().wrongCount()
+    );
+
     List<QuizTypeSummary> quizTypeSummaryList = serviceResponse.getQuizTypeSummaryList().stream()
         .map(summary -> new QuizTypeSummary(
             summary.quizType(),
@@ -70,6 +78,7 @@ public class ReadDashboardController {
 
     return ReadDashboardResponse.builder()
         .quizTypeSummaryList(quizTypeSummaryList)
+        .cumulativeSummary(cumulativeSummary)
         .build();
   }
 }

--- a/src/main/java/org/quizly/quizly/account/dto/response/ReadDashboardResponse.java
+++ b/src/main/java/org/quizly/quizly/account/dto/response/ReadDashboardResponse.java
@@ -16,8 +16,20 @@ import java.util.List;
 @Schema(description = "마이페이지 대시보드 응답")
 public class ReadDashboardResponse {
 
-  @Schema(description = "문제 유형별 통계 (최근 1달)")
+  @Schema(description = "이번 달 누적 학습 통계 (이번 달 1일 ~ 오늘)")
+  private CumulativeSummary cumulativeSummary;
+
+  @Schema(description = "문제 유형별 통계 (이번 달 1일 ~ 오늘)")
   private List<QuizTypeSummary> quizTypeSummaryList;
+
+  public record CumulativeSummary(
+      @Schema(description = "총 풀이 수", example = "100")
+      int solvedCount,
+      @Schema(description = "정답 수", example = "75")
+      int correctCount,
+      @Schema(description = "오답 수", example = "25")
+      int wrongCount
+  ){}
 
   public record QuizTypeSummary(
       @Schema(description = "문제 유형")


### PR DESCRIPTION
- 연관 이슈
    - 이 PR이 해결하는 이슈: Closes #71 (병합 시 자동으로 이슈 닫힘)

- 작업 사항
    - 마이페이지 대시보드 조회 API에 이번 달 누적 학습 통계 필드 추가
    -  추가 배치 작업 없이 기존 `유형별 학습 통계 테이블` 데이터를 집계하여 구현

- 테스트
    -  대시보드 조회 API 호출 시 정상적으로 반환되는지 확인
