### PR TITLE
feat(#76): 주제별 정답률 비교 API - 마이페이지 대시보드

### DIFF
--- a/src/main/java/org/quizly/quizly/account/controller/get/ReadDashboardController.java
+++ b/src/main/java/org/quizly/quizly/account/controller/get/ReadDashboardController.java
@@ -33,7 +33,8 @@ public class ReadDashboardController {
       summary = "마이페이지 대시보드 조회 API",
       description = "현재 로그인 유저의 학습 통계 대시보드 정보를 조회합니다.\n\n"
           + "- 이번 달 누적 학습 통계: 총 풀이 수, 정답 수, 오답 수(이번 달 1일 ~ 오늘)\n"
-          + "- 문제 유형별 통계: 각 유형별 풀이 수, 정답 수, 오답 수(이번 달 1일 ~ 오늘)\n",
+          + "- 문제 유형별 통계: 각 유형별 풀이 수, 정답 수, 오답 수(이번 달 1일 ~ 오늘)\n"
+          + "- 주제 유형별 통계: 각 주제별 풀이 수, 정답 수, 오답 수(최근 6개 주제만 반환)\n",
       operationId = "/account/dashboard"
   )
   @GetMapping("/account/dashboard")
@@ -75,10 +76,20 @@ public class ReadDashboardController {
             summary.wrongCount()
         ))
         .collect(Collectors.toList());
+    List<ReadDashboardResponse.TopicSummary> topicSummaryList = serviceResponse.getTopicSummaryList().stream()
+            .map(summary -> new ReadDashboardResponse.TopicSummary(
+                    summary.topic(),
+                    summary.solvedCount(),
+                    summary.correctCount(),
+                    summary.wrongCount()
+            ))
+            .collect(Collectors.toList());
 
-    return ReadDashboardResponse.builder()
-        .quizTypeSummaryList(quizTypeSummaryList)
-        .cumulativeSummary(cumulativeSummary)
-        .build();
+
+      return ReadDashboardResponse.builder()
+              .quizTypeSummaryList(quizTypeSummaryList)
+              .cumulativeSummary(cumulativeSummary)
+              .topicSummaryList(topicSummaryList)
+              .build();
   }
 }

--- a/src/main/java/org/quizly/quizly/account/dto/response/ReadDashboardResponse.java
+++ b/src/main/java/org/quizly/quizly/account/dto/response/ReadDashboardResponse.java
@@ -22,6 +22,9 @@ public class ReadDashboardResponse {
   @Schema(description = "문제 유형별 통계 (이번 달 1일 ~ 오늘)")
   private List<QuizTypeSummary> quizTypeSummaryList;
 
+  @Schema(description = "주제 유형별 통계 (최근 등록된 6개)")
+  private List<TopicSummary> topicSummaryList;
+
   public record CumulativeSummary(
       @Schema(description = "총 풀이 수", example = "100")
       int solvedCount,
@@ -40,5 +43,16 @@ public class ReadDashboardResponse {
       int correctCount,
       @Schema(description = "오답 수", example = "10")
       int wrongCount
+  ){}
+  public record TopicSummary(
+      @Schema(description = "주제 명")
+      String topic,
+      @Schema(description = "총 풀이 수", example = "50")
+      int solvedCount,
+      @Schema(description = "정답 수", example = "40")
+      int correctCount,
+      @Schema(description = "오답 수", example = "10")
+      int wrongCount
+
   ){}
 }


### PR DESCRIPTION
- 연관 이슈
  - 이 PR이 해결하는 이슈: Closes #76  (병합 시 자동으로 이슈 닫힘)
- 작업 사항
  - 마이페이지 대시보드 조회 API에 최근 6개 주제별 통계 추가
  - Topic 데이터는 최신 6종류만 필요하기 때문에 일 단위 집계가 불필요하여 ReadDashboardService 내부에서 SolveHistory 기반 계산
  - Topic 통계는 API 호출 시 항상 최신 상태 반영
- 테스트
  - 대시보드 조회 API (/account/dashboard) 호출 시 정상적으로 반환되는지 확인
<img width="877" height="1052" alt="image" src="https://github.com/user-attachments/assets/74a839ef-55f9-4361-b061-0aebe9285a1d" />
