### PR TITLE
feat(#75): 시간대별 학습 기록 API (대시보드)

### DIFF
--- a/src/main/java/org/quizly/quizly/account/controller/get/ReadDashboardController.java
+++ b/src/main/java/org/quizly/quizly/account/controller/get/ReadDashboardController.java
@@ -7,6 +7,7 @@ import org.quizly.quizly.account.dto.response.ReadDashboardResponse;
 import org.quizly.quizly.account.dto.response.ReadDashboardResponse.CumulativeSummary;
 import org.quizly.quizly.account.dto.response.ReadDashboardResponse.DailySummary;
 import org.quizly.quizly.account.dto.response.ReadDashboardResponse.QuizTypeSummary;
+import org.quizly.quizly.account.dto.response.ReadDashboardResponse.HourlySummary;
 import org.quizly.quizly.account.service.ReadDashboardService;
 import org.quizly.quizly.account.service.ReadDashboardService.ReadDashboardErrorCode;
 import org.quizly.quizly.account.service.ReadDashboardService.ReadDashboardRequest;
@@ -36,7 +37,8 @@ public class ReadDashboardController {
           + "- 이번 달 누적 학습 통계: 총 풀이 수, 정답 수, 오답 수(이번 달 1일 ~ 오늘)\n"
           + "- 문제 유형별 통계: 각 유형별 풀이 수, 정답 수, 오답 수(이번 달 1일 ~ 오늘)\n"
           + "- 주제 유형별 통계: 각 주제별 풀이 수, 정답 수, 오답 수(최근 6개 주제만 반환)\n"
-          + "- 월별 학습 문제 기록: GitHub 잔디처럼 날짜별 풀이 수 (문제를 푼 날짜만 반환)\n",
+          + "- 월별 학습 문제 기록: GitHub 잔디처럼 날짜별 풀이 수 (문제를 푼 날짜만 반환)\n"
+          + "- 시간대별 학습 패턴: 7개 시간대(0, 6, 9, 12, 15, 18, 21시)별 풀이 수 (모든 시간대 반환)\n",
       operationId = "/account/dashboard"
   )
   @GetMapping("/account/dashboard")
@@ -96,11 +98,19 @@ public class ReadDashboardController {
         ))
         .collect(Collectors.toList());
 
+    List<HourlySummary> hourlySummaryList = serviceResponse.getHourlySummaryList().stream()
+        .map(summary -> new HourlySummary(
+            summary.startHour(),
+            summary.solvedCount()
+        ))
+        .collect(Collectors.toList());
+
     return ReadDashboardResponse.builder()
         .quizTypeSummaryList(quizTypeSummaryList)
         .cumulativeSummary(cumulativeSummary)
         .topicSummaryList(topicSummaryList)
         .dailySummaryList(dailySummaryList)
+        .hourlySummaryList(hourlySummaryList)
         .build();
   }
 }

--- a/src/main/java/org/quizly/quizly/account/dto/response/ReadDashboardResponse.java
+++ b/src/main/java/org/quizly/quizly/account/dto/response/ReadDashboardResponse.java
@@ -29,6 +29,9 @@ public class ReadDashboardResponse {
   @Schema(description = "월별 학습 문제 기록 - 문제를 푼 날짜만 반환")
   private List<DailySummary> dailySummaryList;
 
+  @Schema(description = "시간대별 학습 패턴 (7개 시간대 모두 반환)")
+  private List<HourlySummary> hourlySummaryList;
+
   public record CumulativeSummary(
       @Schema(description = "총 풀이 수", example = "100")
       int solvedCount,
@@ -65,6 +68,13 @@ public class ReadDashboardResponse {
       @Schema(description = "날짜", example = "2025-12-01")
       LocalDate date,
       @Schema(description = "해당 날짜에 푼 문제 수", example = "5")
+      int solvedCount
+  ){}
+
+  public record HourlySummary(
+      @Schema(description = "시작 시각 (0, 6, 9, 12, 15, 18, 21)", example = "9")
+      int startHour,
+      @Schema(description = "해당 시간대에 푼 문제 수", example = "15")
       int solvedCount
   ){}
 }

--- a/src/main/java/org/quizly/quizly/core/domin/entity/SolveHourlySummary.java
+++ b/src/main/java/org/quizly/quizly/core/domin/entity/SolveHourlySummary.java
@@ -31,8 +31,8 @@ public class SolveHourlySummary extends BaseEntity {
   private LocalDate date;
 
   @Column(name = "hour", nullable = false)
-  private Integer hour;
+  private int hour;
 
   @Column(nullable = false)
-  private Integer solvedCount;
+  private int solvedCount;
 }

--- a/src/main/java/org/quizly/quizly/core/domin/repository/SolveHourlySummaryRepository.java
+++ b/src/main/java/org/quizly/quizly/core/domin/repository/SolveHourlySummaryRepository.java
@@ -8,7 +8,6 @@ import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Optional;
 
 public interface SolveHourlySummaryRepository extends JpaRepository<SolveHourlySummary, Long> {
 
@@ -24,10 +23,15 @@ public interface SolveHourlySummaryRepository extends JpaRepository<SolveHourlyS
       @Param("endDate") LocalDate endDate
   );
 
-  Optional<SolveHourlySummary> findByUserAndDateAndHour(
+  List<SolveHourlySummary> findByUserAndDate(
       User user,
-      LocalDate date,
-      Integer hour
+      LocalDate date
+  );
+
+  List<SolveHourlySummary> findByUserAndDateBetween(
+      User user,
+      LocalDate startDate,
+      LocalDate endDate
   );
 
   interface DailySummary {


### PR DESCRIPTION
- 연관 이슈
    - 이 PR이 해결하는 이슈: Closes #75 (병합 시 자동으로 이슈 닫힘)

- 작업 사항
    - 7개 시간대(0, 6, 9, 12, 15, 18, 21시)별 학습 기록 집계 기능 구현
    - 배치로 저장된 과거 데이터와 실시간 오늘 데이터를 통합 집계

- 테스트
    - Dashboard API에서 시간별 풀이 통계가 정상 조회되는지 확인