### PR TITLE
refactor(#82): pdf 분할 코드 리팩토링

### DIFF
--- a/src/main/java/org/quizly/quizly/external/ocr/service/ExtractTextFromOcrService.java
+++ b/src/main/java/org/quizly/quizly/external/ocr/service/ExtractTextFromOcrService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.quizly.quizly.core.application.BaseService;
 import org.quizly.quizly.external.ocr.error.OcrErrorCode;
 import org.springframework.stereotype.Service;
+
 @Service
 @RequiredArgsConstructor
 public class ExtractTextFromOcrService implements BaseService<ClovaOcrService.ClovaOcrRequest, ClovaOcrService.ClovaOcrResponse> {

--- a/src/main/java/org/quizly/quizly/mock/controller/post/CreateMemberMockExamController.java
+++ b/src/main/java/org/quizly/quizly/mock/controller/post/CreateMemberMockExamController.java
@@ -40,12 +40,6 @@ public class CreateMemberMockExamController {
       @RequestBody CreateMemberMockExamRequest request,
       @AuthenticationPrincipal UserPrincipal userPrincipal) {
 
-
-    List<String> chunkList =
-            TextProcessingUtil.createChunkList(
-                    request.getPlainText(), 500, 100
-            );
-
     var serviceResponse =
             createMemberMockExamService.execute(
                     CreateMemberMockExamService.CreateMemberMockExamRequest.builder()
@@ -54,8 +48,6 @@ public class CreateMemberMockExamController {
                             .userPrincipal(userPrincipal)
                             .build()
             );
-
-
 
     if (serviceResponse == null || !serviceResponse.isSuccess()) {
       Optional.ofNullable(serviceResponse)

--- a/src/main/java/org/quizly/quizly/mock/controller/post/CreateMemberOcrMockExamController.java
+++ b/src/main/java/org/quizly/quizly/mock/controller/post/CreateMemberOcrMockExamController.java
@@ -39,7 +39,11 @@ public class CreateMemberOcrMockExamController {
             @RequestParam("mockExamTypeList") List<org.quizly.quizly.mock.dto.request.CreateMemberMockExamRequest.MockExamType> mockExamTypeList,
             @AuthenticationPrincipal UserPrincipal userPrincipal
     ){
-        String plainText = asyncOcrService.extractMergedPlainText(file);
+        String plainText = asyncOcrService.execute(
+            AsyncOcrService.OcrExtractRequest.builder()
+                .file(file)
+                .build()
+        ).getPlainText();
 
         var response = createMemberMockExamService.execute(
                 CreateMemberMockExamRequest.builder()


### PR DESCRIPTION
- 연관 이슈

   - 이 PR이 해결하는 이슈: Closes #82 (병합 시 자동으로 이슈 닫힘)
- 작업 사항


   - 사용되지 않는 로직 삭제(chunkList) : `CreateMemberMockExamController`


   - Async와 supplyAsync가 중복 사용되던 구조를 정리하여, Service execute()를 단일 비동기 진입점으로 통합 : `AsyncOcrService`


   - 코드 리뷰 반영(불필요한 변경) : `ExtractTextFromOcrService`
- 테스트

   - 리팩토링 이전과 동일한 값 반환 확인
