### PR TITLE
feat(#89): 온보딩 설문조사 구현

### DIFF
--- a/src/main/java/org/quizly/quizly/account/controller/get/ReadUserInfoController.java
+++ b/src/main/java/org/quizly/quizly/account/controller/get/ReadUserInfoController.java
@@ -56,6 +56,7 @@ public class ReadUserInfoController {
         .nickName(serviceResponse.getNickName())
         .email(serviceResponse.getEmail())
         .profileImageUrl(serviceResponse.getProfileImageUrl())
+        .onboardingCompleted(serviceResponse.isOnboardingCompleted())
         .build();
   }
 }

--- a/src/main/java/org/quizly/quizly/account/controller/post/CreateOnboardingController.java
+++ b/src/main/java/org/quizly/quizly/account/controller/post/CreateOnboardingController.java
@@ -1,0 +1,53 @@
+package org.quizly.quizly.account.controller.post;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.quizly.quizly.account.dto.request.CreateOnboardingRequest;
+import org.quizly.quizly.account.dto.response.CreateOnboardingResponse;
+import org.quizly.quizly.account.service.CreateOnboardingService;
+import org.quizly.quizly.account.service.CreateOnboardingService.CreateOnboardingErrorCode;
+import org.quizly.quizly.configuration.swagger.ApiErrorCode;
+import org.quizly.quizly.core.exception.error.GlobalErrorCode;
+import org.quizly.quizly.oauth.UserPrincipal;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "Account", description = "계정")
+public class CreateOnboardingController {
+
+    private final CreateOnboardingService createOnboardingService;
+    @Operation(
+        summary = "온보딩 설문조사 API",
+        description = "최초 로그인 시 설문 조사 결과를 저장합니다.",
+        operationId = "/account"
+    )
+    @PostMapping("account/onboarding")
+    @ApiErrorCode(errorCodes = {GlobalErrorCode.class, CreateOnboardingErrorCode.class})
+    public ResponseEntity<CreateOnboardingResponse> onboarding(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @RequestBody CreateOnboardingRequest request
+    ) {
+        createOnboardingService.execute(
+            CreateOnboardingService.CreateOnboardingRequest.builder()
+                .userPrincipal(userPrincipal)
+                .targetType(request.getTargetType())
+                .studyGoal(request.getStudyGoal())
+                .build()
+        );
+
+        return ResponseEntity.ok(toResponse());
+    }
+
+    private CreateOnboardingResponse toResponse() {
+        return CreateOnboardingResponse.builder()
+            .onboardingCompleted(true)
+            .build();
+    }
+}
+

--- a/src/main/java/org/quizly/quizly/account/dto/request/CreateOnboardingRequest.java
+++ b/src/main/java/org/quizly/quizly/account/dto/request/CreateOnboardingRequest.java
@@ -1,0 +1,16 @@
+package org.quizly.quizly.account.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateOnboardingRequest {
+
+    private String targetType;
+
+    private String studyGoal;
+
+}

--- a/src/main/java/org/quizly/quizly/account/dto/response/CreateOnboardingResponse.java
+++ b/src/main/java/org/quizly/quizly/account/dto/response/CreateOnboardingResponse.java
@@ -1,0 +1,18 @@
+package org.quizly.quizly.account.dto.response;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+import org.quizly.quizly.account.service.CreateOnboardingService.CreateOnboardingErrorCode;
+import org.quizly.quizly.core.application.BaseResponse;
+
+@Getter
+@SuperBuilder
+@NoArgsConstructor
+@ToString
+public class CreateOnboardingResponse
+        extends BaseResponse<CreateOnboardingErrorCode> {
+
+    private Boolean onboardingCompleted;
+}

--- a/src/main/java/org/quizly/quizly/account/dto/response/ReadUserInfoResponse.java
+++ b/src/main/java/org/quizly/quizly/account/dto/response/ReadUserInfoResponse.java
@@ -27,4 +27,7 @@ public class ReadUserInfoResponse extends BaseResponse<GlobalErrorCode> {
   @Schema(description = "프로필 url", example = "https://kr.object.ncloudstorage.com/quizly-profile-images/defaults/default_profile.png")
   private String profileImageUrl;
 
+  @Schema(description = "온보딩 설문조사 여부", example = "true")
+  private boolean onboardingCompleted;
+
 }

--- a/src/main/java/org/quizly/quizly/account/service/CreateOnboardingService.java
+++ b/src/main/java/org/quizly/quizly/account/service/CreateOnboardingService.java
@@ -1,0 +1,115 @@
+package org.quizly.quizly.account.service;
+
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+import lombok.extern.log4j.Log4j2;
+import org.quizly.quizly.core.application.BaseRequest;
+import org.quizly.quizly.core.application.BaseResponse;
+import org.quizly.quizly.core.application.BaseService;
+import org.quizly.quizly.core.domin.entity.User;
+import org.quizly.quizly.core.domin.repository.UserRepository;
+import org.quizly.quizly.core.exception.DomainException;
+import org.quizly.quizly.core.exception.error.BaseErrorCode;
+import org.quizly.quizly.oauth.UserPrincipal;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Log4j2
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CreateOnboardingService
+        implements BaseService<
+    CreateOnboardingService.CreateOnboardingRequest,
+    CreateOnboardingService.CreateOnboardingResponse> {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public CreateOnboardingResponse execute(CreateOnboardingRequest request) {
+        if (request == null || !request.isValid()) {
+            return CreateOnboardingResponse.builder()
+                    .success(false)
+                    .errorCode(CreateOnboardingErrorCode.NOT_EXIST_REQUIRED_PARAMETER)
+                    .build();
+        }
+
+        String providerId = request.getUserPrincipal().getProviderId();
+        if (providerId == null || providerId.isBlank()) {
+            return CreateOnboardingResponse.builder()
+                    .success(false)
+                    .errorCode(CreateOnboardingErrorCode.NOT_EXIST_PROVIDER_ID)
+                    .build();
+        }
+
+        Optional<User> userOptional = userRepository.findByProviderId(providerId);
+        if (userOptional.isEmpty()) {
+            log.error("[CreateOnboardingService] User not found for providerId: {}", providerId);
+            return CreateOnboardingResponse.builder()
+                    .success(false)
+                    .errorCode(CreateOnboardingErrorCode.NOT_FOUND_USER)
+                    .build();
+        }
+
+        User user = userOptional.get();
+
+        user.setTargetType(request.getTargetType());
+        user.setStudyGoal(request.getStudyGoal());
+        user.setOnboardingCompleted(true);
+        userRepository.save(user);
+
+        return CreateOnboardingResponse.builder().build();
+    }
+
+    @Getter
+    @RequiredArgsConstructor
+    public enum CreateOnboardingErrorCode implements BaseErrorCode<DomainException> {
+        NOT_EXIST_REQUIRED_PARAMETER(HttpStatus.BAD_REQUEST, "요청 파라미터가 존재하지 않습니다."),
+        NOT_EXIST_PROVIDER_ID(HttpStatus.BAD_REQUEST, "Provider ID가 존재하지 않습니다."),
+        NOT_FOUND_USER(HttpStatus.NOT_FOUND, "유저를 찾을 수 없습니다.");
+
+        private final HttpStatus httpStatus;
+        private final String message;
+
+        @Override
+        public DomainException toException() {
+            return new DomainException(httpStatus, this);
+        }
+    }
+
+    @Getter
+    @Setter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @ToString
+    public static class CreateOnboardingRequest implements BaseRequest {
+        private UserPrincipal userPrincipal;
+        private String targetType;
+        private String studyGoal;
+
+        @Override
+        public boolean isValid() {
+            return userPrincipal != null
+                    && targetType != null
+                    && !targetType.isBlank()
+                    && studyGoal != null
+                    && !studyGoal.isBlank();
+        }
+    }
+
+
+    @Getter
+    @Setter
+    @SuperBuilder
+    @NoArgsConstructor
+    @ToString
+    public static class CreateOnboardingResponse
+            extends BaseResponse<CreateOnboardingErrorCode> {
+        private boolean onboardingCompleted;
+    }
+
+}

--- a/src/main/java/org/quizly/quizly/account/service/ReadUserInfoService.java
+++ b/src/main/java/org/quizly/quizly/account/service/ReadUserInfoService.java
@@ -60,6 +60,7 @@ public class ReadUserInfoService implements BaseService<ReadUserInfoRequest, Rea
         .nickName(user.getNickName())
         .email(user.getEmail())
         .profileImageUrl(user.getProfileImageUrl())
+        .onboardingCompleted(user.isOnboardingCompleted())
         .success(true)
         .build();
   }
@@ -107,6 +108,7 @@ public class ReadUserInfoService implements BaseService<ReadUserInfoRequest, Rea
     private String nickName;
     private String email;
     private String profileImageUrl;
+    private boolean onboardingCompleted;
   }
 
 }

--- a/src/main/java/org/quizly/quizly/core/domin/entity/User.java
+++ b/src/main/java/org/quizly/quizly/core/domin/entity/User.java
@@ -2,11 +2,7 @@ package org.quizly.quizly.core.domin.entity;
 
 import jakarta.persistence.*;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 import lombok.experimental.SuperBuilder;
 import org.quizly.quizly.core.domin.shared.BaseEntity;
 
@@ -65,6 +61,16 @@ public class User extends BaseEntity {
 
   @Column(nullable = true)
   private String profileImageUrl;
+
+  @Column(nullable = true)
+  private String targetType;
+
+  @Column(nullable = true)
+  private String studyGoal;
+
+  @Column(nullable = false)
+  @Builder.Default
+  private boolean onboardingCompleted = false;
 
   @PrePersist
   public void setDefaultProfileImage() {


### PR DESCRIPTION
- 연관 이슈
   - 이 PR이 해결하는 이슈: Closes #89 (병합 시 자동으로 이슈 닫힘)
   
- 작업 사항
   - 온보딩 설문조사 API 구현 (account/onboarding)
   - UserInfo 조회 시 onboardingCompleted true 여부에 따라 온보딩 화면 노출 여부 조절 가능
  
- 테스트
  - Post 요청 결과 DB 반영 및 UserInfo 조회에서도 확인