### PR TITLE
feat(#95): 실서버 배포 (main 브랜치)

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,0 +1,73 @@
+name: Quizly Deploy (NCP)
+
+on:
+  push:
+    branches: [ "main" ]
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Source Code
+        uses: actions/checkout@v3
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Make application.yml
+        run: |
+          mkdir -p ./src/main/resources
+          echo "${{ secrets.APPLICATION_YML_PROD }}" > ./src/main/resources/application.yml
+
+      - name: Build with Gradle
+        run: |
+          chmod +x gradlew
+          ./gradlew clean build -x test
+
+      - name: Transfer Config to Server
+        uses: appleboy/scp-action@master
+        with:
+          host: ${{ secrets.NCP_HOST_PROD }}
+          username: ${{ secrets.NCP_USERNAME_PROD }}
+          password: ${{ secrets.NCP_PASSWORD_PROD }}
+          port: ${{ secrets.NCP_PORT_PROD }}
+          source: "./src/main/resources/application.yml"
+          target: "/root/quizly-server"
+          strip_components: 4
+
+      - name: Transfer Script to Server
+        uses: appleboy/scp-action@master
+        with:
+          host: ${{ secrets.NCP_HOST_PROD }}
+          username: ${{ secrets.NCP_USERNAME_PROD }}
+          password: ${{ secrets.NCP_PASSWORD_PROD }}
+          port: ${{ secrets.NCP_PORT_PROD }}
+          source: "./deploy-prod.sh"
+          target: "/root/quizly-server"
+
+      - name: Build & Push to NCR
+        run: |
+          echo "Logging into NCR..."
+          docker login ${{ secrets.NCP_CONTAINER_REGISTRY }} -u ${{ secrets.NCP_ACCESS_KEY }} -p ${{ secrets.NCP_SECRET_KEY }}
+          
+          echo "Building Image..."
+          docker build -t ${{ secrets.NCP_CONTAINER_REGISTRY }}/quizly:${{ github.sha }} .
+          
+          echo "Pushing Image..."
+          docker push ${{ secrets.NCP_CONTAINER_REGISTRY }}/quizly:${{ github.sha }}
+
+      - name: Execute Deploy Script
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.NCP_HOST_PROD }}
+          username: ${{ secrets.NCP_USERNAME_PROD }}
+          password: ${{ secrets.NCP_PASSWORD_PROD }}
+          port: ${{ secrets.NCP_PORT_PROD }}
+          script: |
+            docker login ${{ secrets.NCP_CONTAINER_REGISTRY }} -u ${{ secrets.NCP_ACCESS_KEY }} -p ${{ secrets.NCP_SECRET_KEY }}
+            cd /root/quizly-server
+            chmod +x deploy-prod.sh
+            ./deploy-prod.sh ${{ secrets.NCP_CONTAINER_REGISTRY }}/quizly ${{ github.sha }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,5 @@
-FROM openjdk:17.0.2-jdk-slim AS build
-WORKDIR /app
-COPY build.gradle settings.gradle gradlew ./
-COPY gradle ./gradle
-RUN chmod +x ./gradlew && sed -i 's/\r$//' ./gradlew && ./gradlew dependencies
-COPY . .
-RUN ./gradlew bootJar
-
 FROM openjdk:17.0.2-jdk-slim
 WORKDIR /app
-COPY --from=build /app/build/libs/*.jar app.jar
+COPY build/libs/*.jar app.jar
 EXPOSE 8080
-ENTRYPOINT ["java","-jar","app.jar"]
+ENTRYPOINT ["java", "-Duser.timezone=Asia/Seoul", "-jar", "app.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -57,11 +57,16 @@ dependencies {
 	//batch
 	implementation 'org.springframework.boot:spring-boot-starter-batch'
 	testImplementation 'org.springframework.batch:spring-batch-test'
+
 	// Apache PDF Box
 	implementation group: 'org.apache.pdfbox', name: 'pdfbox', version: '2.0.31'
 
 	// Open AI
 	implementation("com.openai:openai-java:4.15.0")
+
+	// Actuator
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
 
 
 }

--- a/deploy-prod.sh
+++ b/deploy-prod.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+set -euo pipefail
+
+IMAGE_PATH=$1
+IMAGE_TAG=$2
+FULL_IMAGE_NAME="${IMAGE_PATH}:${IMAGE_TAG}"
+
+echo "> 배포 시작: $FULL_IMAGE_NAME"
+
+if [ ! -f /etc/nginx/conf.d/service-url.inc ]; then
+    echo "set \$service_url http://127.0.0.1:8080;" | sudo tee /etc/nginx/conf.d/service-url.inc
+fi
+
+CURRENT_PORT=$(cat /etc/nginx/conf.d/service-url.inc | grep -o '[0-9]*' | tail -1)
+
+if [ "$CURRENT_PORT" -eq 8080 ]; then
+  TARGET_PORT=8081
+  TARGET_NAME="backend-green"
+else
+  TARGET_PORT=8080
+  TARGET_NAME="backend-blue"
+fi
+
+echo "> 타겟 포트: $TARGET_PORT"
+
+docker pull $FULL_IMAGE_NAME
+docker rm -f "$TARGET_NAME" 2>/dev/null || true
+
+docker run -d --name $TARGET_NAME -p ${TARGET_PORT}:8080 \
+  -v /root/quizly-server/application.yml:/application.yml \
+  --memory="1280m" \
+  $FULL_IMAGE_NAME
+
+echo "> Health Check (http://localhost:${TARGET_PORT}/)..."
+for RETRY in {1..5}; do
+  RESPONSE_CODE=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:${TARGET_PORT}/actuator/health || echo "000")
+
+  if [ "$RESPONSE_CODE" -eq 200 ]; then
+      echo "> Health Check 성공! (응답 코드: $RESPONSE_CODE)"
+      break
+  fi
+
+  if [ $RETRY -eq 5 ]; then
+      echo "> Health Check 실패. (마지막 응답 코드: $RESPONSE_CODE)"
+      echo "> 컨테이너 로그:"
+      docker logs $TARGET_NAME --tail 20
+      docker stop $TARGET_NAME
+      exit 1
+  fi
+
+  echo "> 대기 중... ($RETRY/5 - 응답 코드: $RESPONSE_CODE)"
+  sleep 10
+done
+
+echo "set \$service_url http://127.0.0.1:${TARGET_PORT};" | sudo tee /etc/nginx/conf.d/service-url.inc
+sudo service nginx reload
+
+if [ "$CURRENT_PORT" -eq 8080 ]; then
+  docker stop backend-blue 2>/dev/null || true
+  docker rm backend-blue 2>/dev/null || true
+else
+  docker stop backend-green 2>/dev/null || true
+  docker rm backend-green 2>/dev/null || true
+fi
+docker image prune -f
+
+echo "> 배포 완료!"

--- a/src/main/java/org/quizly/quizly/configuration/CorsMvcConfig.java
+++ b/src/main/java/org/quizly/quizly/configuration/CorsMvcConfig.java
@@ -15,11 +15,18 @@ public class CorsMvcConfig {
   @Value("${custom.oauth2.front-redirect-url}")
   private String frontRedirectUrl;
 
+  @Value("${cors.allowed-origins}")
+  private List<String> corsAllowedOrigins;
+
 
   @Bean
   public CorsConfigurationSource corsConfigurationSource() {
     CorsConfiguration configuration = new CorsConfiguration();
-    configuration.setAllowedOrigins(List.of("http://localhost:5173",frontRedirectUrl));
+
+    List<String> allowedOrigins = new java.util.ArrayList<>(corsAllowedOrigins);
+    allowedOrigins.add(frontRedirectUrl);
+
+    configuration.setAllowedOrigins(allowedOrigins);
     configuration.setAllowedMethods(List.of("*"));
     configuration.setAllowedHeaders(List.of("*"));
     configuration.setAllowCredentials(true);

--- a/src/main/java/org/quizly/quizly/configuration/SecurityConfig.java
+++ b/src/main/java/org/quizly/quizly/configuration/SecurityConfig.java
@@ -61,7 +61,8 @@ public class SecurityConfig {
                 "/api-docs/**",
                 "/auth/reissue",
                 "/quizzes/guest/**",
-                "/quizzes/{quizId}/answer/guest"
+                "/quizzes/{quizId}/answer/guest",
+                "/actuator/health"
             ).permitAll()
             .anyRequest().authenticated());
 


### PR DESCRIPTION
- 연관 이슈
    - 이 PR이 해결하는 이슈: Closes #95 (병합 시 자동으로 이슈 닫힘)

- 작업 사항
    -  NCP(Naver Cloud Platform)를 통한 prod 배포 자동화 파이프라인 구축
    -  Blue-Green 무중단 배포 전략 구현으로 서비스 다운타임 제거
    - 기술 블로그
        - [실서버 배포 아키텍쳐 및 과정](https://chanyoung-kwon.notion.site/CICD-277e5ea23d6b804789f5cd511872a1bd?source=copy_link)
        - [무중단 배포 안정성 테스트](https://chanyoung-kwon.notion.site/2eee5ea23d6b8073a9b9da0603de6198?source=copy_link)

- 테스트
    - 해당 브랜치를 배포 후 api 정상 작동 테스트 완료

- 주의 사항
    - 소셜 로그인 개발자 센터에 Callback URL에 배포 URL 추가
        - [x] 네이버
        - [x] 카카오
    - DB[prod]
        1. schema_spring_batch 적용 완료
        2. 인덱스 설정 문서화 필요