### PR TITLE
feat(#108): 로그아웃 api 구현

### DIFF
--- a/src/main/java/org/quizly/quizly/core/domin/repository/RefreshTokenRepository.java
+++ b/src/main/java/org/quizly/quizly/core/domin/repository/RefreshTokenRepository.java
@@ -7,4 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
 
   Optional<RefreshToken> findByProviderId(String providerId);
+
+  void deleteByProviderId(String providerId);
 }

--- a/src/main/java/org/quizly/quizly/oauth/controller/delete/RevokeRefreshTokenController.java
+++ b/src/main/java/org/quizly/quizly/oauth/controller/delete/RevokeRefreshTokenController.java
@@ -1,0 +1,65 @@
+package org.quizly.quizly.oauth.controller.delete;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.quizly.quizly.configuration.swagger.ApiErrorCode;
+import org.quizly.quizly.core.application.BaseResponse;
+import org.quizly.quizly.core.exception.error.GlobalErrorCode;
+import org.quizly.quizly.oauth.UserPrincipal;
+import org.quizly.quizly.oauth.service.RevokeRefreshTokenService;
+import org.quizly.quizly.oauth.service.RevokeRefreshTokenService.RevokeRefreshTokenErrorCode;
+import org.quizly.quizly.oauth.service.RevokeRefreshTokenService.RevokeRefreshTokenRequest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "Auth", description = "인증")
+public class RevokeRefreshTokenController {
+
+  private final RevokeRefreshTokenService revokeRefreshTokenService;
+
+  @Operation(
+      summary = "리프레시 토큰 무효화 API (로그아웃)",
+      description = "인증된 사용자의 리프레시 토큰을 무효화하고 쿠키를 삭제합니다.",
+      operationId = "/auth/logout"
+  )
+  @DeleteMapping("/auth/logout")
+  @ApiErrorCode(errorCodes = {GlobalErrorCode.class, RevokeRefreshTokenErrorCode.class})
+  public ResponseEntity<Void> revokeRefreshToken(
+      @AuthenticationPrincipal UserPrincipal userPrincipal,
+      HttpServletResponse response
+  ) {
+
+    var serviceResponse = revokeRefreshTokenService.execute( RevokeRefreshTokenRequest.builder()
+        .providerId(userPrincipal.getProviderId())
+        .build());
+
+    if (!serviceResponse.isSuccess()) {
+      Optional.of(serviceResponse)
+          .map(BaseResponse::getErrorCode)
+          .ifPresent(errorCode -> {
+            throw errorCode.toException();
+          });
+    }
+
+    ResponseCookie cookie = ResponseCookie.from("refreshToken", "")
+        .httpOnly(true)
+        .secure(true)
+        .path("/")
+        .sameSite("Lax")
+        .maxAge(0)
+        .build();
+
+    response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+
+    return ResponseEntity.ok().build();
+  }
+}

--- a/src/main/java/org/quizly/quizly/oauth/service/RevokeRefreshTokenService.java
+++ b/src/main/java/org/quizly/quizly/oauth/service/RevokeRefreshTokenService.java
@@ -1,0 +1,86 @@
+package org.quizly.quizly.oauth.service;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+import lombok.extern.slf4j.Slf4j;
+import org.quizly.quizly.core.application.BaseRequest;
+import org.quizly.quizly.core.application.BaseResponse;
+import org.quizly.quizly.core.application.BaseService;
+import org.quizly.quizly.core.domin.repository.RefreshTokenRepository;
+import org.quizly.quizly.core.exception.DomainException;
+import org.quizly.quizly.core.exception.error.BaseErrorCode;
+import org.quizly.quizly.oauth.service.RevokeRefreshTokenService.RevokeRefreshTokenRequest;
+import org.quizly.quizly.oauth.service.RevokeRefreshTokenService.RevokeRefreshTokenResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class RevokeRefreshTokenService implements BaseService<RevokeRefreshTokenRequest, RevokeRefreshTokenResponse> {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    @Override
+    public RevokeRefreshTokenResponse execute(RevokeRefreshTokenRequest revokeRefreshTokenRequest) {
+        String providerId = revokeRefreshTokenRequest.getProviderId();
+
+        if (!revokeRefreshTokenRequest.isValid()) {
+            return RevokeRefreshTokenResponse.builder()
+                .success(false)
+                .errorCode(RevokeRefreshTokenErrorCode.PROVIDER_ID_MISSING)
+                .build();
+        }
+
+        refreshTokenRepository.deleteByProviderId(providerId);
+
+        return RevokeRefreshTokenResponse.builder()
+            .success(true)
+            .build();
+    }
+
+    @Getter
+    @RequiredArgsConstructor
+    public enum RevokeRefreshTokenErrorCode implements BaseErrorCode<DomainException> {
+        PROVIDER_ID_MISSING(HttpStatus.BAD_REQUEST, "사용자 인증 정보가 제공되지 않았습니다.");
+
+        private final HttpStatus httpStatus;
+        private final String message;
+
+        @Override
+        public DomainException toException() {
+            return new DomainException(httpStatus, this);
+        }
+    }
+
+    @Getter
+    @Setter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @ToString
+    public static class RevokeRefreshTokenRequest implements BaseRequest {
+        private String providerId;
+
+        @Override
+        public boolean isValid() {
+            return providerId != null && !providerId.isEmpty();
+        }
+    }
+
+    @Getter
+    @Setter
+    @SuperBuilder
+    @NoArgsConstructor
+    @ToString
+    public static class RevokeRefreshTokenResponse extends BaseResponse<RevokeRefreshTokenErrorCode> {
+    }
+}


### PR DESCRIPTION
- 연관 이슈
   - 이 PR이 해결하는 이슈: close #108  (병합 시 자동으로 이슈 닫힘)
   
- 작업 사항
    - `feat(#108): 로그아웃 api 구현`
        - 요청 사용자의 Refresh Token(DB) 삭제 + refreshToken 쿠키 삭제
    - ~`refactor(NONE): 네이밍 컨벤션으로 수정 (AccessTokenReissue* 클래스)`~ 
        -  ~기존 `AccessTokenReissue` → `ReissueAccessToken` 패턴으로 변경 (프로젝트 내 다른 컨트롤러 네이밍 통일성 유지)~
        - ~로그아웃 구현 중 발견사항으로 해당 PR에서 수정하였습니다.~

---
- `refactor(NONE): 네이밍 컨벤션으로 수정 (AccessTokenReissue* 클래스)` 커밋은 [코드 리뷰](https://github.com/Quizly-Team/backend/pull/109#discussion_r2752223534) 중 추가 이슈 발견하여 관련 작업 #110 분리 및 이관하였습니다.
