### PR TITLE
feat(#103): 배치 실패 시 Slack 알림 봇 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,8 +58,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-batch'
 	testImplementation 'org.springframework.batch:spring-batch-test'
 
-	// Apache PDF Box
+	// Apache
 	implementation group: 'org.apache.pdfbox', name: 'pdfbox', version: '2.0.31'
+	implementation "org.apache.httpcomponents.client5:httpclient5"
 
 	// Open AI
 	implementation("com.openai:openai-java:4.15.0")

--- a/src/main/java/org/quizly/quizly/batch/listener/BatchFailureAlertListener.java
+++ b/src/main/java/org/quizly/quizly/batch/listener/BatchFailureAlertListener.java
@@ -1,0 +1,54 @@
+package org.quizly.quizly.batch.listener;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.quizly.quizly.batch.message.BatchFailureNotificationMessage;
+import org.quizly.quizly.core.notification.NotificationProvider;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobExecutionListener;
+import org.springframework.stereotype.Component;
+
+import java.util.stream.Collectors;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class BatchFailureAlertListener implements JobExecutionListener {
+
+    private final NotificationProvider notificationProvider;
+
+    @Override
+    public void afterJob(JobExecution jobExecution) {
+        if (jobExecution.getStatus() == BatchStatus.FAILED) {
+
+            String jobName = jobExecution.getJobInstance().getJobName();
+
+            String reason = jobExecution.getAllFailureExceptions().isEmpty()
+                ? "unknown"
+                : jobExecution.getAllFailureExceptions().get(0).getMessage();
+
+            String step = jobExecution.getStepExecutions().stream()
+                    .filter(se -> se.getStatus() == BatchStatus.FAILED)
+                    .map(se -> se.getStepName() + " (" + se.getExitStatus().getExitCode() + ")")
+                    .collect(Collectors.joining(", "));
+
+
+            String parameters = formatJobParameters(jobExecution);
+
+            notificationProvider.send(
+                new BatchFailureNotificationMessage(jobName, reason, step, parameters)
+            );
+        }
+    }
+
+    private String formatJobParameters(JobExecution jobExecution){
+        return jobExecution.getJobParameters()
+            .getParameters()
+            .entrySet()
+            .stream()
+            .map(e -> e.getKey() + "=" + e.getValue().getValue())
+            .collect(Collectors.joining(", "));
+    }
+
+}

--- a/src/main/java/org/quizly/quizly/batch/message/BatchFailureNotificationMessage.java
+++ b/src/main/java/org/quizly/quizly/batch/message/BatchFailureNotificationMessage.java
@@ -1,0 +1,30 @@
+package org.quizly.quizly.batch.message;
+
+import org.quizly.quizly.core.notification.NotificationMessage;
+
+public class BatchFailureNotificationMessage implements NotificationMessage {
+
+    private final String jobName;
+    private final String reason;
+
+    private final String step;
+
+    private final String parameters;
+
+    public BatchFailureNotificationMessage(String jobName, String reason, String step, String parameters) {
+        this.jobName = jobName;
+        this.reason = reason;
+        this.step = step;
+        this.parameters = parameters;
+    }
+
+    @Override
+    public String title() {
+        return "Batch Failure";
+    }
+
+    @Override
+    public String body() {
+        return "job=" + jobName + "\nreason=" + reason + "\nstep=" + step + "\nparameters=" + parameters;
+    }
+}

--- a/src/main/java/org/quizly/quizly/configuration/RestClientConfig.java
+++ b/src/main/java/org/quizly/quizly/configuration/RestClientConfig.java
@@ -1,0 +1,31 @@
+package org.quizly.quizly.configuration;
+
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.core5.util.Timeout;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.Duration;
+
+@Configuration
+public class RestClientConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+
+        HttpComponentsClientHttpRequestFactory factory = new HttpComponentsClientHttpRequestFactory();
+        factory.setConnectTimeout(Duration.ofSeconds(3));
+
+        CloseableHttpClient httpClient = HttpClients.custom()
+            .setDefaultRequestConfig(RequestConfig.custom()
+                .setResponseTimeout(Timeout.ofSeconds(3))
+                .build())
+            .build();
+        factory.setHttpClient(httpClient);
+        return new RestTemplate(factory);
+    }
+}

--- a/src/main/java/org/quizly/quizly/core/notification/NotificationMessage.java
+++ b/src/main/java/org/quizly/quizly/core/notification/NotificationMessage.java
@@ -1,0 +1,6 @@
+package org.quizly.quizly.core.notification;
+
+public interface NotificationMessage {
+    String title();
+    String body();
+}

--- a/src/main/java/org/quizly/quizly/core/notification/NotificationProvider.java
+++ b/src/main/java/org/quizly/quizly/core/notification/NotificationProvider.java
@@ -1,0 +1,5 @@
+package org.quizly.quizly.core.notification;
+
+public interface NotificationProvider {
+    void send(NotificationMessage message);
+}

--- a/src/main/java/org/quizly/quizly/external/slack/dto/Request/SlackRequest.java
+++ b/src/main/java/org/quizly/quizly/external/slack/dto/Request/SlackRequest.java
@@ -1,0 +1,4 @@
+package org.quizly.quizly.external.slack.dto.Request;
+
+public record SlackRequest(String text) {
+}

--- a/src/main/java/org/quizly/quizly/external/slack/service/NoOpSlackNotificationService.java
+++ b/src/main/java/org/quizly/quizly/external/slack/service/NoOpSlackNotificationService.java
@@ -1,0 +1,15 @@
+package org.quizly.quizly.external.slack.service;
+
+import org.quizly.quizly.core.notification.NotificationMessage;
+import org.quizly.quizly.core.notification.NotificationProvider;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+
+@Profile({"local"})
+@Service
+public class NoOpSlackNotificationService implements NotificationProvider {
+    @Override
+    public void send(NotificationMessage message) {
+
+    }
+}

--- a/src/main/java/org/quizly/quizly/external/slack/service/SlackNotificationService.java
+++ b/src/main/java/org/quizly/quizly/external/slack/service/SlackNotificationService.java
@@ -1,0 +1,102 @@
+package org.quizly.quizly.external.slack.service;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import lombok.extern.slf4j.Slf4j;
+import org.quizly.quizly.core.application.BaseRequest;
+import org.quizly.quizly.core.application.BaseResponse;
+import org.quizly.quizly.core.application.BaseService;
+import org.quizly.quizly.core.exception.DomainException;
+import org.quizly.quizly.core.exception.error.BaseErrorCode;
+import org.quizly.quizly.core.notification.NotificationMessage;
+import org.quizly.quizly.core.notification.NotificationProvider;
+import org.quizly.quizly.external.slack.dto.Request.SlackRequest;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.core.env.Environment;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+@Profile({"dev", "prod"})
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SlackNotificationService implements NotificationProvider, BaseService<SlackNotificationService.NotificationRequest, SlackNotificationService.NotificationResponse> {
+
+    @Value("${notification.slack.webhook-url}")
+    private String webhookUrl;
+
+    private final RestTemplate restTemplate;
+    private final Environment environment;
+
+    @Override
+    public void send(NotificationMessage message) {
+        if (message == null) {
+            return;
+        }
+        String text = format(message);
+        this.execute(new NotificationRequest(text));
+    }
+
+    private String format(NotificationMessage message) {
+        String[] profiles = environment.getActiveProfiles();
+        String profile = profiles.length > 0 ? profiles[0].toUpperCase() : "UNKNOWN";
+        return "[" + profile + "] [" + message.title() + "]\n" + message.body();
+    }
+    @Override
+    public NotificationResponse execute(NotificationRequest request) {
+        if (request == null || !request.isValid()) {
+            return NotificationResponse.builder().success(false).build();
+        }
+
+        try {
+            SlackRequest slackRequest = new SlackRequest(request.getMessage());
+            restTemplate.postForEntity(webhookUrl, slackRequest, String.class);
+
+            return NotificationResponse.builder()
+                .success(true)
+                .build();
+        } catch (RestClientException e) {
+            log.error("[SlackNotificationService] 전송 실패", e);
+            return NotificationResponse.builder()
+                .success(false)
+                .errorCode(NotificationErrorCode.SEND_FAILED)
+                .build();
+        }
+    }
+    @Getter
+    @RequiredArgsConstructor
+    public enum NotificationErrorCode implements BaseErrorCode<DomainException> {
+        SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "알림 전송 중 오류가 발생했습니다.");
+
+        private final HttpStatus httpStatus;
+        private final String message;
+
+        @Override
+        public DomainException toException() {
+            return new DomainException(httpStatus, this);
+        }
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class NotificationRequest implements BaseRequest {
+        private String message;
+
+        @Override
+        public boolean isValid() {
+            return message != null && !message.isBlank();
+        }
+    }
+
+    @Getter
+    @SuperBuilder
+    @NoArgsConstructor
+    public static class NotificationResponse extends BaseResponse<NotificationErrorCode> {
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -2,6 +2,8 @@ server:
   name: Quizly
 
 spring:
+  profiles:
+    active: dev
   datasource:
     url: ${DB_URL}
     username: ${DB_USERNAME}


### PR DESCRIPTION
- 연관 이슈
   - 이 PR이 해결하는 이슈: close #103  (병합 시 자동으로 이슈 닫힘)
   
- 작업 사항
   - SlackNotificationService를 NotificationProvider로 분리하여 알림 전송 로직을 공통화
   - 배치 작업뿐 아니라 일반 서비스 로직(ex. 추후 결제 로직)에서도 동일한 방식으로 알림을 사용할 수 있도록 구조 정리
          - 결제 처리 흐름에서는 결제 응답을 우선 반환하고, 알림 전송만 별도로 비동기 처리하는 구조로 확장 가능

   - 현재 배치는 새벽 시간대에만 실행되고, 알림 또한 이중 확인 용도로 사용되기 때문에 비동기 방식(webClient) 대신 동기 방식(RestTemplate)을 사용해도 충분하다고 논의완료
   - Slack 전송 실패 시에도 배치 로직 자체에는 영향을 주지 않도록 timeout  처리

- 테스트
    - 강제 배치 중단 로직 BatchFailureAlertListener.beforeJob()을 두어 배치 실패 시 슬랙 알림 오는 것을 확인
       <img width="616" height="161" alt="image" src="https://github.com/user-attachments/assets/15b63dcd-a427-4430-be0b-436f925a6c78" />
