### PR TITLE
feat(#114): 인덱스 정리 및 쿼리 튜닝

### DIFF
--- a/mysql/index.sql
+++ b/mysql/index.sql
@@ -1,0 +1,17 @@
+-- solve_history
+
+# 사용처 : findLatestSolveHistoriesByUser
+CREATE INDEX idx_solve_history_user_quiz_created
+    ON solve_history(user_id, quiz_id, created_at DESC);
+
+# 사용처 : findLatestWrongSolveHistoriesByUser
+CREATE INDEX idx_solve_history_user_correct_quiz_created
+    ON solve_history(user_id, is_correct, quiz_id, created_at DESC);
+
+# 사용처 : aggregationUserReader
+CREATE INDEX idx_solve_history_submitted_user
+    ON solve_history(submitted_at, user_id);
+
+# 사용처 : findFirstAttemptsByQuizTypeAndDate, findHourlySummaryByUserAndDate
+CREATE INDEX idx_solve_history_user_submitted
+    ON solve_history(user_id, submitted_at);

--- a/src/main/java/org/quizly/quizly/batch/step/AggregationUserReaderConfig.java
+++ b/src/main/java/org/quizly/quizly/batch/step/AggregationUserReaderConfig.java
@@ -1,10 +1,14 @@
 package org.quizly.quizly.batch.step;
 
-import jakarta.persistence.EntityManagerFactory;
+import javax.sql.DataSource;
 import lombok.RequiredArgsConstructor;
 import org.quizly.quizly.core.domin.entity.User;
+import org.quizly.quizly.core.domin.entity.User.Provider;
+import org.quizly.quizly.core.domin.entity.User.Role;
 import org.springframework.batch.core.configuration.annotation.StepScope;
-import org.springframework.batch.item.database.JpaPagingItemReader;
+import org.springframework.batch.item.database.JdbcPagingItemReader;
+import org.springframework.batch.item.database.Order;
+import org.springframework.batch.item.database.support.MySqlPagingQueryProvider;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -17,35 +21,61 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class AggregationUserReaderConfig {
 
-  private final EntityManagerFactory entityManagerFactory;
+  private final DataSource dataSource;
 
   @Bean
   @StepScope
-  public JpaPagingItemReader<User> aggregationUserReader(
+  public JdbcPagingItemReader<User> aggregationUserReader(
       @Value("#{jobParameters['targetDate']}") String targetDateStr) {
 
     LocalDate targetDate = LocalDate.parse(targetDateStr);
     LocalDateTime startDateTime = targetDate.atStartOfDay();
     LocalDateTime endDateTime = targetDate.plusDays(1).atStartOfDay();
 
-    JpaPagingItemReader<User> reader = new JpaPagingItemReader<>();
-    reader.setName("aggregationUserReader");
-    reader.setEntityManagerFactory(entityManagerFactory);
-    reader.setQueryString(
-        "SELECT u FROM User u " +
+    MySqlPagingQueryProvider queryProvider = new MySqlPagingQueryProvider();
+    queryProvider.setSelectClause("SELECT u.*");
+    queryProvider.setFromClause("FROM user u");
+    queryProvider.setWhereClause(
         "WHERE EXISTS (" +
-        "  SELECT 1 FROM SolveHistory sh " +
-        "  WHERE sh.user.id = u.id " +
-        "  AND sh.submittedAt >= :startDateTime " +
-        "  AND sh.submittedAt < :endDateTime" +
-        ") " +
-        "ORDER BY u.id ASC"
+        "  SELECT 1 FROM solve_history sh USE INDEX (idx_solve_history_submitted_user)" +
+        "  WHERE sh.user_id = u.id" +
+        "  AND sh.submitted_at >= :startDateTime" +
+        "  AND sh.submitted_at < :endDateTime" +
+        ")"
     );
+    queryProvider.setSortKeys(Map.of("id", Order.ASCENDING));
+
+    JdbcPagingItemReader<User> reader = new JdbcPagingItemReader<>();
+    reader.setName("aggregationUserReader");
+    reader.setDataSource(dataSource);
+    reader.setQueryProvider(queryProvider);
     reader.setParameterValues(Map.of(
         "startDateTime", startDateTime,
         "endDateTime", endDateTime
     ));
     reader.setPageSize(20);
+    reader.setRowMapper((rs, rowNum) -> {
+      String provider = rs.getString("provider");
+
+      return User.builder()
+          .id(rs.getLong("id"))
+          .name(rs.getString("name"))
+          .nickName(rs.getString("nick_name"))
+          .email(rs.getString("email"))
+          .role(Role.valueOf(rs.getString("role")))
+          .profileImageUrl(rs.getString("profile_image_url"))
+          .targetType(rs.getString("target_type"))
+          .studyGoal(rs.getString("study_goal"))
+          .onboardingCompleted(rs.getBoolean("onboarding_completed"))
+          .createdAt(rs.getTimestamp("created_at") != null
+              ? rs.getTimestamp("created_at").toLocalDateTime() : null)
+          .updatedAt(rs.getTimestamp("updated_at") != null
+              ? rs.getTimestamp("updated_at").toLocalDateTime() : null)
+          .deleted(rs.getBoolean("deleted"))
+          .provider(provider != null ? Provider.valueOf(provider) : null)
+          .providerId(rs.getString("provider_id"))
+          .build();
+    });
 
     return reader;
   }

--- a/src/main/java/org/quizly/quizly/core/domin/repository/QuizRepository.java
+++ b/src/main/java/org/quizly/quizly/core/domin/repository/QuizRepository.java
@@ -4,11 +4,6 @@ import java.util.List;
 import org.quizly.quizly.core.domin.entity.Quiz;
 import org.quizly.quizly.core.domin.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
 public interface QuizRepository extends JpaRepository<Quiz, Long> {
-  List<Quiz> findAllByUser(User user);
-
-  @Query("SELECT DISTINCT q FROM Quiz q LEFT JOIN FETCH q.options WHERE q.user = :user")
-  List<Quiz> findAllByUserWithOptions(User user);
 }

--- a/src/main/java/org/quizly/quizly/core/domin/repository/SolveHistoryRepository.java
+++ b/src/main/java/org/quizly/quizly/core/domin/repository/SolveHistoryRepository.java
@@ -20,7 +20,7 @@ public interface SolveHistoryRepository extends JpaRepository<SolveHistory, Long
       Quiz quiz
   );
 
-  @Query("SELECT sh FROM SolveHistory sh LEFT JOIN FETCH sh.quiz WHERE sh.user = :user AND (sh.quiz.id, sh.createdAt) IN (SELECT sh2.quiz.id, MAX(sh2.createdAt) FROM SolveHistory sh2 WHERE sh2.user = :user GROUP BY sh2.quiz.id)")
+  @Query("SELECT DISTINCT sh FROM SolveHistory sh LEFT JOIN FETCH sh.quiz q LEFT JOIN FETCH q.options WHERE sh.user = :user AND (sh.quiz.id, sh.createdAt) IN (SELECT sh2.quiz.id, MAX(sh2.createdAt) FROM SolveHistory sh2 WHERE sh2.user = :user GROUP BY sh2.quiz.id)")
   List<SolveHistory> findLatestSolveHistoriesByUser(@Param("user") User user);
 
   @Query("SELECT sh FROM SolveHistory sh LEFT JOIN FETCH sh.quiz WHERE sh.user = :user AND sh.isCorrect = FALSE AND (sh.quiz.id, sh.createdAt) IN (SELECT sh2.quiz.id, MAX(sh2.createdAt) FROM SolveHistory sh2 WHERE sh2.user = :user GROUP BY sh2.quiz.id)")

--- a/src/main/java/org/quizly/quizly/quiz/service/ReadQuizzesService.java
+++ b/src/main/java/org/quizly/quizly/quiz/service/ReadQuizzesService.java
@@ -1,6 +1,5 @@
 package org.quizly.quizly.quiz.service;
 
-import java.util.Collections;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -20,7 +19,6 @@ import org.quizly.quizly.core.domin.entity.User;
 import org.quizly.quizly.account.service.ReadUserService;
 import org.quizly.quizly.account.service.ReadUserService.ReadUserRequest;
 import org.quizly.quizly.account.service.ReadUserService.ReadUserResponse;
-import org.quizly.quizly.core.domin.repository.QuizRepository;
 import org.quizly.quizly.core.domin.repository.SolveHistoryRepository;
 import org.quizly.quizly.core.exception.DomainException;
 import org.quizly.quizly.core.exception.error.BaseErrorCode;
@@ -36,7 +34,6 @@ import org.springframework.stereotype.Service;
 public class ReadQuizzesService implements BaseService<ReadQuizzesRequest, ReadQuizzesResponse> {
 
   private final ReadUserService readUserService;
-  private final QuizRepository quizRepository;
   private final SolveHistoryRepository solveHistoryRepository;
 
   @Override
@@ -62,16 +59,11 @@ public class ReadQuizzesService implements BaseService<ReadQuizzesRequest, ReadQ
     }
     User user = readUserResponse.getUser();
 
-    List<Quiz> quizList = quizRepository.findAllByUserWithOptions(user);
-    if (quizList.isEmpty()) {
-      return ReadQuizzesResponse.builder()
-          .success(true)
-          .quizList(quizList)
-          .solveHistoryList(Collections.emptyList())
-          .build();
-    }
-    List<SolveHistory> latestSolveHistoryList = solveHistoryRepository.findLatestSolveHistoriesByUser(
-        user);
+    List<SolveHistory> latestSolveHistoryList = solveHistoryRepository.findLatestSolveHistoriesByUser(user);
+
+    List<Quiz> quizList = latestSolveHistoryList.stream()
+        .map(SolveHistory::getQuiz)
+        .toList();
 
     return ReadQuizzesResponse.builder()
         .quizList(quizList)


### PR DESCRIPTION
- 연관 이슈
   - 이 PR이 해결하는 이슈: close #114  (병합 시 자동으로 이슈 닫힘)
   
- 작업 사항
    1. 인덱스 정리
    2. AggregationUserReader JDBC 전환
        -> USE INDEX (idx_solve_history_submitted_user) 적용으로 배치 Reader 쿼리 성능 개선 (기존 Jpa 방식으로 불가능하여 전환)
    3. `/quizzes` API 쿼리 최적화
        -> `findLatestSolveHistoriesByUser` 1개 쿼리로 통합 (`findAllByUserWithOptions` + `findLatestSolveHistoriesByUser`)
        -> 리팩토링 이전에는 문제 풀이 시에만 SolveHistory가 생성되어 Quiz 전체 조회 쿼리를 별도로 사용했지만, 현재 문제 제작 직후 SolveHistory가 함께 생성되어 SolveHistory가 보장되므로 별도 Quiz 조회 쿼리 없이 SolveHistory 단일 쿼리로 통합

- 참고 자료
    - 실행 계획 분석 및 index 설계 과정 ([노션](https://chanyoung-kwon.notion.site/Index-2fce5ea23d6b80b6bf95f016fb047d4e?source=copy_link))

- 주의 사항
    - [ ] 실서버 merge 이전 시점에 index.sql 적용 
