### PR TITLE
feat(#116): 사용자 문의(Inquiry) 도메인 기반 기능

### DIFF
--- a/src/main/java/org/quizly/quizly/core/domin/entity/Inquiry.java
+++ b/src/main/java/org/quizly/quizly/core/domin/entity/Inquiry.java
@@ -1,0 +1,45 @@
+package org.quizly.quizly.core.domin.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+import org.quizly.quizly.core.domin.shared.BaseEntity;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@SuperBuilder
+@Entity
+@Table(name = "inquiry")
+public class Inquiry extends BaseEntity {
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false)
+    private String content;
+    @Getter
+    @RequiredArgsConstructor
+    public enum Status{
+        WAITING("답변 대기중"),
+        COMPLETED("답변 완료");
+
+        private final String description;
+    }
+    @Column(nullable = true)
+    private String reply;
+
+    @Column(nullable = true)
+    private LocalDateTime repliedAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Status status;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+}

--- a/src/main/java/org/quizly/quizly/core/domin/repository/InquiryRepository.java
+++ b/src/main/java/org/quizly/quizly/core/domin/repository/InquiryRepository.java
@@ -1,0 +1,11 @@
+package org.quizly.quizly.core.domin.repository;
+
+import org.quizly.quizly.core.domin.entity.Inquiry;
+import org.quizly.quizly.core.domin.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface InquiryRepository extends JpaRepository<Inquiry,Long> {
+    List<Inquiry> findAllByUser(User user);
+}

--- a/src/main/java/org/quizly/quizly/inquiry/controller/get/ReadInquiriesController.java
+++ b/src/main/java/org/quizly/quizly/inquiry/controller/get/ReadInquiriesController.java
@@ -1,0 +1,74 @@
+package org.quizly.quizly.inquiry.controller.get;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.quizly.quizly.configuration.swagger.ApiErrorCode;
+import org.quizly.quizly.core.application.BaseResponse;
+import org.quizly.quizly.core.domin.entity.Inquiry;
+import org.quizly.quizly.core.exception.error.GlobalErrorCode;
+import org.quizly.quizly.oauth.UserPrincipal;
+import org.quizly.quizly.inquiry.dto.response.ReadInquiriesResponse;
+import org.quizly.quizly.inquiry.service.ReadInquiriesService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Optional;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "Inquiry", description = "문의")
+public class ReadInquiriesController {
+
+    private final ReadInquiriesService readInquiriesService;
+
+    @Operation(
+        summary = "사용자 문의 조회 API",
+        description = "사용자가 등록한 문의 사항을 조회합니다.",
+        operationId = "/inquiries"
+    )
+    @GetMapping("/inquiries")
+    @ApiErrorCode(errorCodes = {GlobalErrorCode.class, ReadInquiriesService.ReadInquiriesErrorCode.class})
+    public ResponseEntity<ReadInquiriesResponse> readInquiries(@AuthenticationPrincipal UserPrincipal userPrincipal){
+        ReadInquiriesService.ReadInquiriesResponse serviceResponse = readInquiriesService.execute(
+            ReadInquiriesService.ReadInquiriesRequest.builder()
+                .userPrincipal(userPrincipal)
+                .build()
+        );
+
+        if (serviceResponse == null || !serviceResponse.isSuccess()) {
+            Optional.ofNullable(serviceResponse)
+                .map(BaseResponse::getErrorCode)
+                .ifPresentOrElse(errorCode -> {
+                    throw errorCode.toException();
+                }, () -> {
+                    throw GlobalErrorCode.INTERNAL_ERROR.toException();
+                });
+        }
+
+        return ResponseEntity.ok(toResponse(serviceResponse.getInquiryList()));
+    }
+    private ReadInquiriesResponse toResponse(List<Inquiry> inquiryList){
+        return ReadInquiriesResponse.builder()
+            .success(true)
+            .inquiryList(
+                inquiryList.stream()
+                    .map(i->new ReadInquiriesResponse.InquiryDetail(
+                        i.getId(),
+                        i.getTitle(),
+                        i.getContent(),
+                        i.getReply(),
+                        i.getRepliedAt(),
+                        i.getStatus(),
+                        i.getCreatedAt(),
+                        i.getUpdatedAt()
+                    ))
+                    .toList()
+            )
+            .build();
+    }
+
+}

--- a/src/main/java/org/quizly/quizly/inquiry/controller/post/CreateInquiryController.java
+++ b/src/main/java/org/quizly/quizly/inquiry/controller/post/CreateInquiryController.java
@@ -1,0 +1,64 @@
+package org.quizly.quizly.inquiry.controller.post;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.quizly.quizly.configuration.swagger.ApiErrorCode;
+import org.quizly.quizly.core.application.BaseResponse;
+import org.quizly.quizly.core.exception.error.GlobalErrorCode;
+import org.quizly.quizly.oauth.UserPrincipal;
+import org.quizly.quizly.inquiry.dto.request.CreateInquiryRequest;
+import org.quizly.quizly.inquiry.dto.response.CreateInquiryResponse;
+import org.quizly.quizly.inquiry.service.CreateInquiryService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Optional;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "Inquiry", description = "문의")
+public class CreateInquiryController {
+
+    private final CreateInquiryService createInquiryService;
+
+    @Operation(
+        summary = "사용자 문의 등록 API",
+        description = "서비스 문의 사항에 대해 사용자가 문의를 등록합니다.",
+        operationId = "/inquiries"
+    )
+    @PostMapping("/inquiries")
+    @ApiErrorCode(errorCodes = {GlobalErrorCode.class, CreateInquiryService.CreateInquiryErrorCode.class})
+    public ResponseEntity<CreateInquiryResponse> createInquiry(@AuthenticationPrincipal UserPrincipal userPrincipal,
+                                                                                    @RequestBody CreateInquiryRequest request){
+        CreateInquiryService.CreateInquiryResponse serviceResponse = createInquiryService.execute(
+            CreateInquiryService.CreateInquiryRequest.builder()
+                .userPrincipal(userPrincipal)
+                .title(request.getTitle())
+                .content(request.getContent())
+                .build()
+        );
+
+        if (serviceResponse == null || !serviceResponse.isSuccess()) {
+            Optional.ofNullable(serviceResponse)
+                .map(BaseResponse::getErrorCode)
+                .ifPresentOrElse(errorCode -> {
+                    throw errorCode.toException();
+                }, () -> {
+                    throw GlobalErrorCode.INTERNAL_ERROR.toException();
+                });
+        }
+
+        return ResponseEntity.ok(toResponse(serviceResponse));
+    }
+
+    private CreateInquiryResponse toResponse(CreateInquiryService.CreateInquiryResponse serviceResponse){
+        return CreateInquiryResponse.builder()
+            .inquiryId(serviceResponse.getInquiryId())
+            .status(serviceResponse.getStatus())
+            .build();
+    }
+}

--- a/src/main/java/org/quizly/quizly/inquiry/dto/request/CreateInquiryRequest.java
+++ b/src/main/java/org/quizly/quizly/inquiry/dto/request/CreateInquiryRequest.java
@@ -1,0 +1,28 @@
+package org.quizly.quizly.inquiry.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.quizly.quizly.core.application.BaseRequest;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "문의 생성 요청")
+public class CreateInquiryRequest implements BaseRequest {
+
+    @Schema(description = "문의 제목" , example = "모의 고사 문제 제작 관련 기능을 추가 해주실 수 있나요?")
+    private String title;
+
+    @Schema(description = "문의 내용" , example = "모의 고사 문제를 만들고 나서, 새로 고침하면 이전에 만들었던 문제가 사라지는데,\n 이전에 만들었던 문제들을 쭉 모아볼 수 있는 기능을 추가해주실 수 있나요? ")
+    private String content;
+
+    @Override
+    public boolean isValid(){
+        return title != null && !title.isBlank() && content != null && !content.isBlank();
+    }
+
+}

--- a/src/main/java/org/quizly/quizly/inquiry/dto/response/CreateInquiryResponse.java
+++ b/src/main/java/org/quizly/quizly/inquiry/dto/response/CreateInquiryResponse.java
@@ -1,0 +1,26 @@
+package org.quizly.quizly.inquiry.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+import org.quizly.quizly.core.application.BaseResponse;
+import org.quizly.quizly.core.domin.entity.Inquiry;
+import org.quizly.quizly.core.exception.error.GlobalErrorCode;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@SuperBuilder
+@Schema(description = "문의 생성 응답")
+public class CreateInquiryResponse extends BaseResponse<GlobalErrorCode> {
+
+    @Schema(description = "문의 ID", example = "1")
+    private Long inquiryId;
+
+    @Schema(description = "문의 상태", example = "답변 대기중")
+    private Inquiry.Status status;
+}

--- a/src/main/java/org/quizly/quizly/inquiry/dto/response/ReadInquiriesResponse.java
+++ b/src/main/java/org/quizly/quizly/inquiry/dto/response/ReadInquiriesResponse.java
@@ -1,0 +1,47 @@
+package org.quizly.quizly.inquiry.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+import org.quizly.quizly.core.application.BaseResponse;
+import org.quizly.quizly.core.domin.entity.Inquiry;
+import org.quizly.quizly.core.exception.error.GlobalErrorCode;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@ToString
+@SuperBuilder
+@Schema(description = "내 문의 목록 조회 응답")
+public class ReadInquiriesResponse extends BaseResponse<GlobalErrorCode> {
+
+    @Schema(description = "내 문의 목록")
+    private List<InquiryDetail> inquiryList;
+
+    @Schema(description = "내 문의 목록 상세")
+    public record InquiryDetail(
+        @Schema(description = "문의 ID", example = "1")
+        Long inquiryId,
+        @Schema(description = "문의 제목")
+        String title,
+        @Schema(description = "문의 내용")
+        String content,
+        @Schema(description = "답변")
+        String reply,
+        @Schema(description = "답변 일자")
+        LocalDateTime repliedAt,
+        @Schema(description = "답변 상태")
+        Inquiry.Status status,
+        @Schema(description = "생성 일자")
+        LocalDateTime createdAt,
+        @Schema(description = "수정 일자")
+        LocalDateTime updatedAt
+
+
+    ){};
+
+}

--- a/src/main/java/org/quizly/quizly/inquiry/service/CreateInquiryService.java
+++ b/src/main/java/org/quizly/quizly/inquiry/service/CreateInquiryService.java
@@ -1,0 +1,115 @@
+package org.quizly.quizly.inquiry.service;
+
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+import lombok.extern.log4j.Log4j2;
+import org.quizly.quizly.account.service.ReadUserService;
+import org.quizly.quizly.core.application.BaseRequest;
+import org.quizly.quizly.core.application.BaseResponse;
+import org.quizly.quizly.core.application.BaseService;
+import org.quizly.quizly.core.domin.entity.Inquiry;
+import org.quizly.quizly.core.domin.entity.User;
+import org.quizly.quizly.core.domin.repository.InquiryRepository;
+import org.quizly.quizly.core.exception.DomainException;
+import org.quizly.quizly.core.exception.error.BaseErrorCode;
+import org.quizly.quizly.oauth.UserPrincipal;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class CreateInquiryService implements BaseService<CreateInquiryService.CreateInquiryRequest, CreateInquiryService.CreateInquiryResponse> {
+
+    private final ReadUserService readUserService;
+    private final InquiryRepository inquiryRepository;
+
+    @Override
+    public CreateInquiryResponse execute(CreateInquiryRequest request) {
+        if(request == null || !request.isValid()){
+            return CreateInquiryResponse.builder()
+                .success(false)
+                .errorCode(CreateInquiryErrorCode.NOT_EXIST_REQUIRED_PARAMETER)
+                .build();
+        }
+
+        ReadUserService.ReadUserResponse readUserResponse = readUserService.execute(
+            ReadUserService.ReadUserRequest
+                .builder()
+                .userPrincipal(request.getUserPrincipal())
+                .build()
+        );
+
+        if(!readUserResponse.isSuccess()){
+            return CreateInquiryResponse.builder()
+                .success(false)
+                .errorCode(CreateInquiryErrorCode.NOT_FOUND_USER)
+                .build();
+        }
+
+        User user = readUserResponse.getUser();
+
+        Inquiry inquiry = Inquiry.builder()
+            .title(request.getTitle())
+            .content(request.getContent())
+            .status(Inquiry.Status.WAITING)
+            .user(user)
+            .build();
+
+
+        Inquiry savedInquiry = inquiryRepository.save(inquiry);
+        return CreateInquiryResponse.builder()
+            .success(true)
+            .inquiryId(savedInquiry.getId())
+            .status(savedInquiry.getStatus())
+            .build();
+    }
+
+
+
+    @Getter
+    @RequiredArgsConstructor
+    public enum CreateInquiryErrorCode implements BaseErrorCode<DomainException> {
+        NOT_EXIST_REQUIRED_PARAMETER(HttpStatus.BAD_REQUEST, "요청 파라미터가 존재하지 않습니다."),
+        NOT_FOUND_USER(HttpStatus.NOT_FOUND, "유저를 찾을 수 없습니다.");
+
+
+        private final HttpStatus httpStatus;
+
+        private final String message;
+
+        @Override
+        public DomainException toException() {
+            return new DomainException(httpStatus, this);
+        }
+    }
+    @Getter
+    @Setter
+    @SuperBuilder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class CreateInquiryRequest implements BaseRequest{
+        private UserPrincipal userPrincipal;
+        private String title;
+        private String content;
+
+        @Override
+        public boolean isValid(){
+            return userPrincipal != null && title != null && !title.isBlank() && content !=null && !content.isBlank();
+        }
+    }
+
+    @Getter
+    @Setter
+    @SuperBuilder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class CreateInquiryResponse extends BaseResponse<CreateInquiryErrorCode>{
+        private Long inquiryId;
+        private Inquiry.Status status;
+    }
+}
+
+
+

--- a/src/main/java/org/quizly/quizly/inquiry/service/ReadInquiriesService.java
+++ b/src/main/java/org/quizly/quizly/inquiry/service/ReadInquiriesService.java
@@ -1,0 +1,104 @@
+package org.quizly.quizly.inquiry.service;
+
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+import lombok.extern.log4j.Log4j2;
+import org.quizly.quizly.account.service.ReadUserService;
+import org.quizly.quizly.core.application.BaseRequest;
+import org.quizly.quizly.core.application.BaseResponse;
+import org.quizly.quizly.core.application.BaseService;
+import org.quizly.quizly.core.domin.entity.Inquiry;
+import org.quizly.quizly.core.domin.entity.User;
+import org.quizly.quizly.core.domin.repository.InquiryRepository;
+import org.quizly.quizly.inquiry.service.ReadInquiriesService.ReadInquiriesRequest;
+import org.quizly.quizly.inquiry.service.ReadInquiriesService.ReadInquiriesResponse;
+import org.quizly.quizly.core.exception.DomainException;
+import org.quizly.quizly.core.exception.error.BaseErrorCode;
+import org.quizly.quizly.oauth.UserPrincipal;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ReadInquiriesService implements BaseService<ReadInquiriesRequest,ReadInquiriesResponse> {
+
+    private final ReadUserService readUserService;
+    private final InquiryRepository inquiryRepository;
+
+    @Override
+    public ReadInquiriesResponse execute(ReadInquiriesRequest request) {
+
+        if(request == null || !request.isValid()){
+            return ReadInquiriesResponse.builder()
+                .success(false)
+                .errorCode(ReadInquiriesErrorCode.NOT_EXIST_REQUIRED_PARAMETER)
+                .build();
+        }
+        ReadUserService.ReadUserResponse readUserResponse = readUserService.execute(
+            ReadUserService.ReadUserRequest.builder()
+                .userPrincipal(request.getUserPrincipal())
+                .build()
+        );
+
+        if(!readUserResponse.isSuccess()){
+            return ReadInquiriesResponse.builder()
+                .success(false)
+                .errorCode(ReadInquiriesErrorCode.NOT_FOUND_USER)
+                .build();
+        }
+        User user = readUserResponse.getUser();
+
+        List<Inquiry> inquiryList = inquiryRepository.findAllByUser(user);
+
+        return ReadInquiriesResponse.builder()
+            .success(true)
+            .inquiryList(inquiryList)
+            .build();
+    }
+
+    @Getter
+    @RequiredArgsConstructor
+    public enum ReadInquiriesErrorCode implements BaseErrorCode<DomainException>{
+        NOT_EXIST_REQUIRED_PARAMETER(HttpStatus.BAD_REQUEST, "요청 파라미터가 존재하지 않습니다."),
+        NOT_FOUND_USER(HttpStatus.NOT_FOUND, "유저를 찾을 수 없습니다.");
+
+        private final HttpStatus httpStatus;
+        private final String message;
+
+        @Override
+        public DomainException toException() {
+            return new DomainException(httpStatus, this);
+        }
+    }
+
+    @Getter
+    @Setter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @ToString
+    public static class ReadInquiriesRequest implements BaseRequest{
+        private UserPrincipal userPrincipal;
+
+        @Override
+        public boolean isValid() {
+            return userPrincipal != null;
+        }
+    }
+
+    @Getter
+    @Setter
+    @SuperBuilder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @ToString
+    public static class ReadInquiriesResponse extends BaseResponse<ReadInquiriesErrorCode>{
+
+        private List<Inquiry> inquiryList;
+
+    }
+}


### PR DESCRIPTION
- 연관 이슈
   - 이 PR이 해결하는 이슈: close #116  (병합 시 자동으로 이슈 닫힘)
   
- 작업 사항
   - inquiry 패키지 하에 /inquiry,  /inquiries 로 API 구현
   - QnA issue 1 : 유저 기반 QNA 이슈 
       - [x] 질문 등록 API
       - [x] 내 질문 조회 API
       - [x] 기본 질문 status 설계
   - status : WAITING / COMPLETED 
        - 문의 등록시 WATING상태, 관리자가 답변 등록 시 COMPLETED 상태 전환
- 주의 사항
   - ' qna ' 대신 ' inquiry (문의)' 사용으로 [question, answer] 와 서비스 내의 [quiz, answer]가 중복되지 않도록 [inquriy와 reply]로 설계
   - 다음 issue2인 관리자 기반 QNA 이슈에서는 해당 서비스 활용하여 admin 패키지 하에서 작업 예정
   - reply를 별도의 엔티티로 두지 않음 - > Inquiry의 필드로서 quiz 엔티티의 answer와 비슷한 형태 . 답변 등록 시 필드를 업데이트 하는 방식으로 구현 예정

- 테스트
   - 문의 등록 , 조회 모두 정상 반환 완료 