### PR TITLE
feat(#118): faq 등록 API 구현 (Admin API)

### DIFF
--- a/src/main/java/org/quizly/quizly/admin/controller/post/BatchAggregateSummaryController.java
+++ b/src/main/java/org/quizly/quizly/admin/controller/post/BatchAggregateSummaryController.java
@@ -1,4 +1,4 @@
-package org.quizly.quizly.admin.controller;
+package org.quizly.quizly.admin.controller.post;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;

--- a/src/main/java/org/quizly/quizly/admin/controller/post/CreateFaqController.java
+++ b/src/main/java/org/quizly/quizly/admin/controller/post/CreateFaqController.java
@@ -1,0 +1,70 @@
+package org.quizly.quizly.admin.controller.post;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.quizly.quizly.admin.dto.request.CreateFaqRequest;
+import org.quizly.quizly.admin.dto.response.CreateFaqResponse;
+import org.quizly.quizly.admin.service.CreateFaqService;
+import org.quizly.quizly.admin.service.CreateFaqService.CreateFaqErrorCode;
+import org.quizly.quizly.configuration.swagger.ApiErrorCode;
+import org.quizly.quizly.core.application.BaseResponse;
+import org.quizly.quizly.core.exception.error.GlobalErrorCode;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@Log4j2
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "Admin", description = "관리자")
+public class CreateFaqController {
+
+  private final CreateFaqService createFaqService;
+
+  @Operation(
+      summary = "FAQ 등록 API",
+      description = "관리자 전용 API로 FAQ를 등록합니다.\n\n"
+          + "- 카테고리: SERVICE_INTRO(서비스 소개), QUIZ_GENERATION(문제 생성), WRONG_ANSWER(오답 관리), TECH_SUPPORT(기술 지원)",
+      operationId = "/admin/faqs"
+  )
+  @PostMapping("/admin/faqs")
+  @PreAuthorize("hasRole('ADMIN')")
+  @ApiErrorCode(errorCodes = {GlobalErrorCode.class, CreateFaqErrorCode.class})
+  public ResponseEntity<CreateFaqResponse> createFaq(
+      @Valid @RequestBody CreateFaqRequest request
+  ) {
+    CreateFaqService.CreateFaqResponse serviceResponse = createFaqService.execute(
+        CreateFaqService.CreateFaqRequest.builder()
+            .category(request.getCategory())
+            .question(request.getQuestion())
+            .answer(request.getAnswer())
+            .build()
+    );
+
+    if (serviceResponse == null || !serviceResponse.isSuccess()) {
+      Optional.ofNullable(serviceResponse)
+          .map(BaseResponse::getErrorCode)
+          .ifPresentOrElse(errorCode -> {
+            throw errorCode.toException();
+          }, () -> {
+            throw GlobalErrorCode.INTERNAL_ERROR.toException();
+          });
+    }
+
+    return ResponseEntity.status(HttpStatus.CREATED).body(
+        CreateFaqResponse.builder()
+            .faqId(serviceResponse.getFaqId())
+            .category(request.getCategory())
+            .question(request.getQuestion())
+            .answer(request.getAnswer())
+            .build()
+    );
+  }
+}

--- a/src/main/java/org/quizly/quizly/admin/dto/request/CreateFaqRequest.java
+++ b/src/main/java/org/quizly/quizly/admin/dto/request/CreateFaqRequest.java
@@ -1,0 +1,31 @@
+package org.quizly.quizly.admin.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.quizly.quizly.core.application.BaseRequest;
+import org.quizly.quizly.core.domin.entity.Faq.FaqCategory;
+
+@Getter
+@SuperBuilder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "FAQ 등록 요청")
+public class CreateFaqRequest implements BaseRequest {
+
+  @Schema(description = "FAQ 카테고리", example = "SERVICE_INTRO")
+  private FaqCategory category;
+
+  @Schema(description = "FAQ 질문", example = "Quizly는 어떤 서비스인가요?")
+  private String question;
+
+  @Schema(description = "FAQ 답변", example = "Quizly는 AI 기반 퀴즈 생성 서비스입니다.")
+  private String answer;
+
+  @Override
+  public boolean isValid() {
+    return category != null && question != null && answer != null;
+  }
+}

--- a/src/main/java/org/quizly/quizly/admin/dto/response/CreateFaqResponse.java
+++ b/src/main/java/org/quizly/quizly/admin/dto/response/CreateFaqResponse.java
@@ -1,0 +1,28 @@
+package org.quizly.quizly.admin.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.quizly.quizly.core.application.BaseResponse;
+import org.quizly.quizly.core.domin.entity.Faq.FaqCategory;
+import org.quizly.quizly.core.exception.error.GlobalErrorCode;
+
+@Getter
+@SuperBuilder
+@NoArgsConstructor
+@Schema(description = "FAQ 등록 응답")
+public class CreateFaqResponse extends BaseResponse<GlobalErrorCode> {
+
+  @Schema(description = "등록된 FAQ ID", example = "1")
+  private Long faqId;
+
+  @Schema(description = "FAQ 카테고리", example = "SERVICE_INTRO")
+  private FaqCategory category;
+
+  @Schema(description = "FAQ 질문", example = "Quizly는 어떤 서비스인가요?")
+  private String question;
+
+  @Schema(description = "FAQ 답변", example = "Quizly는 AI 기반 퀴즈 생성 서비스입니다.")
+  private String answer;
+}

--- a/src/main/java/org/quizly/quizly/admin/service/CreateFaqService.java
+++ b/src/main/java/org/quizly/quizly/admin/service/CreateFaqService.java
@@ -1,0 +1,82 @@
+package org.quizly.quizly.admin.service;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import lombok.extern.log4j.Log4j2;
+import org.quizly.quizly.admin.service.CreateFaqService.CreateFaqRequest;
+import org.quizly.quizly.admin.service.CreateFaqService.CreateFaqResponse;
+import org.quizly.quizly.core.application.BaseRequest;
+import org.quizly.quizly.core.application.BaseResponse;
+import org.quizly.quizly.core.application.BaseService;
+import org.quizly.quizly.core.domin.entity.Faq;
+import org.quizly.quizly.core.domin.entity.Faq.FaqCategory;
+import org.quizly.quizly.core.domin.repository.FaqRepository;
+import org.quizly.quizly.core.exception.DomainException;
+import org.quizly.quizly.core.exception.error.BaseErrorCode;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CreateFaqService implements BaseService<CreateFaqRequest, CreateFaqResponse> {
+
+  private final FaqRepository faqRepository;
+
+  @Override
+  public CreateFaqResponse execute(CreateFaqRequest request) {
+    if (request == null || !request.isValid()) {
+      return CreateFaqResponse.builder()
+          .success(false)
+          .errorCode(CreateFaqErrorCode.NOT_EXIST_REQUIRED_PARAMETER)
+          .build();
+    }
+
+    Faq faq = Faq.builder()
+        .category(request.getCategory())
+        .question(request.getQuestion())
+        .answer(request.getAnswer())
+        .build();
+
+    Faq savedFaq = faqRepository.save(faq);
+
+    return CreateFaqResponse.builder()
+        .faqId(savedFaq.getId())
+        .build();
+  }
+
+  @Getter
+  @RequiredArgsConstructor
+  public enum CreateFaqErrorCode implements BaseErrorCode<DomainException> {
+
+    NOT_EXIST_REQUIRED_PARAMETER(HttpStatus.BAD_REQUEST, "필수 파라미터가 누락되었습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    @Override
+    public DomainException toException() {
+      return new DomainException(httpStatus, this);
+    }
+  }
+
+  @Getter
+  @Builder
+  public static class CreateFaqRequest implements BaseRequest {
+    private FaqCategory category;
+    private String question;
+    private String answer;
+
+    @Override
+    public boolean isValid() {
+      return category != null && question != null && answer != null;
+    }
+  }
+
+  @Getter
+  @SuperBuilder
+  public static class CreateFaqResponse extends BaseResponse<CreateFaqErrorCode> {
+    private Long faqId;
+  }
+}

--- a/src/main/java/org/quizly/quizly/core/domin/entity/Faq.java
+++ b/src/main/java/org/quizly/quizly/core/domin/entity/Faq.java
@@ -1,0 +1,45 @@
+package org.quizly.quizly.core.domin.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+import org.quizly.quizly.core.domin.shared.BaseEntity;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@SuperBuilder
+@Entity
+@Table(name = "faq")
+public class Faq extends BaseEntity {
+
+  @Getter
+  @RequiredArgsConstructor
+  public enum FaqCategory {
+    SERVICE_INTRO("서비스 소개"),
+    QUIZ_GENERATION("문제 생성"),
+    WRONG_ANSWER("오답 관리"),
+    TECH_SUPPORT("기술 지원");
+
+    private final String description;
+  }
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private FaqCategory category;
+
+  @Column(nullable = false)
+  private String question;
+
+  @Column(columnDefinition = "TEXT", nullable = false)
+  private String answer;
+}

--- a/src/main/java/org/quizly/quizly/core/domin/repository/FaqRepository.java
+++ b/src/main/java/org/quizly/quizly/core/domin/repository/FaqRepository.java
@@ -1,0 +1,7 @@
+package org.quizly.quizly.core.domin.repository;
+
+import org.quizly.quizly.core.domin.entity.Faq;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FaqRepository extends JpaRepository<Faq, Long> {
+}


### PR DESCRIPTION
- 연관 이슈
   - 이 PR이 해결하는 이슈: close #118  (병합 시 자동으로 이슈 닫힘)
   
- 작업 사항
    -  Admin 전용 FAQ 등록 API 구현
    - 기획에 따른 FAQ 카테고리 4종 정의 (`SERVICE_INTRO`, `QUIZ_GENERATION`, `WRONG_ANSWER`, `TECH_SUPPORT`)

- 테스트
    - Admin 계정으로만 등록 가능 여부 확인 완료 하였습니다.