### PR TITLE
feat(#122): qna 관리자 문의 조회 기능

### DIFF
--- a/src/main/java/org/quizly/quizly/admin/controller/get/AdminReadInquiriesController.java
+++ b/src/main/java/org/quizly/quizly/admin/controller/get/AdminReadInquiriesController.java
@@ -1,0 +1,77 @@
+package org.quizly.quizly.admin.controller.get;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+import lombok.RequiredArgsConstructor;
+import org.quizly.quizly.admin.dto.response.AdminReadInquiriesResponse;
+import org.quizly.quizly.admin.service.AdminReadInquiriesService;
+import org.quizly.quizly.configuration.swagger.ApiErrorCode;
+import org.quizly.quizly.core.application.BaseResponse;
+import org.quizly.quizly.core.domin.entity.Inquiry;
+import org.quizly.quizly.core.exception.error.GlobalErrorCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Optional;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "Admin", description = "관리자")
+public class AdminReadInquiriesController {
+    private final AdminReadInquiriesService adminReadInquiriesService;
+
+    @Operation(
+        summary = "관리자 문의 전체 조회 API",
+        description = "사용자가 등록한 문의를 전체 조회합니다.\n\n",
+        operationId = "/admin/inquiries"
+    )
+    @GetMapping("/admin/inquiries")
+    @PreAuthorize("hasRole('ADMIN')")
+    @ApiErrorCode(errorCodes = {GlobalErrorCode.class, AdminReadInquiriesService.AdminReadInquiriesErrorCode.class})
+    public ResponseEntity<AdminReadInquiriesResponse> adminReadInquiries(
+        @RequestParam(required = false) Inquiry.Status status
+        ){
+        AdminReadInquiriesService.AdminReadInquiriesResponse serviceResponse = adminReadInquiriesService.execute(
+            AdminReadInquiriesService.AdminReadInquiriesRequest.builder()
+                .status(status)
+                .build()
+        );
+        if (serviceResponse == null || !serviceResponse.isSuccess()) {
+            Optional.ofNullable(serviceResponse)
+                .map(BaseResponse::getErrorCode)
+                .ifPresentOrElse(errorCode -> {
+                    throw errorCode.toException();
+                }, () -> {
+                    throw GlobalErrorCode.INTERNAL_ERROR.toException();
+                });
+        }
+
+        return ResponseEntity.ok(toResponse(serviceResponse.getInquiryList()));
+    }
+
+    private AdminReadInquiriesResponse toResponse(List<Inquiry> inquiryList){
+        List<AdminReadInquiriesResponse.AdminInquiryDetail> details = inquiryList.stream()
+            .map(inquiry -> new AdminReadInquiriesResponse.AdminInquiryDetail(
+                inquiry.getId(),
+                inquiry.getTitle(),
+                inquiry.getContent(),
+                inquiry.getUser().getName(),
+                inquiry.getUser().getId(),
+                inquiry.getReply(),
+                inquiry.getRepliedAt(),
+                inquiry.getStatus(),
+                inquiry.getCreatedAt(),
+                inquiry.getUpdatedAt()
+            )).toList();
+
+        return AdminReadInquiriesResponse.builder()
+            .inquiryList(details)
+            .build();
+    }
+
+}

--- a/src/main/java/org/quizly/quizly/admin/dto/response/AdminReadInquiriesResponse.java
+++ b/src/main/java/org/quizly/quizly/admin/dto/response/AdminReadInquiriesResponse.java
@@ -1,0 +1,47 @@
+package org.quizly.quizly.admin.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.quizly.quizly.core.application.BaseResponse;
+import org.quizly.quizly.core.domin.entity.Inquiry;
+import org.quizly.quizly.core.exception.error.GlobalErrorCode;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@SuperBuilder
+@NoArgsConstructor
+@Schema(description = "관리자 문의 조회 응답")
+public class AdminReadInquiriesResponse extends BaseResponse<GlobalErrorCode> {
+    @Schema(description = "전체 문의 목록")
+    private List<AdminInquiryDetail> inquiryList;
+
+    @Schema(description = "전체 문의 목록 상세")
+    public record AdminInquiryDetail(
+        @Schema(description = "문의 ID", example = "1")
+        Long inquiryId,
+        @Schema(description = "문의 제목")
+        String title,
+        @Schema(description = "문의 내용")
+        String content,
+        @Schema(description = "작성자 이름")
+        String writerName,
+        @Schema(description = "작성자 ID")
+        Long writerId,
+        @Schema(description = "답변")
+        String reply,
+        @Schema(description = "답변 일자")
+        LocalDateTime repliedAt,
+        @Schema(description = "답변 상태")
+        Inquiry.Status status,
+        @Schema(description = "생성 일자")
+        LocalDateTime createdAt,
+        @Schema(description = "수정 일자")
+        LocalDateTime updatedAt
+
+
+    ){};
+}

--- a/src/main/java/org/quizly/quizly/admin/service/AdminReadInquiriesService.java
+++ b/src/main/java/org/quizly/quizly/admin/service/AdminReadInquiriesService.java
@@ -1,0 +1,95 @@
+package org.quizly.quizly.admin.service;
+
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+import org.quizly.quizly.core.application.BaseRequest;
+import org.quizly.quizly.core.application.BaseResponse;
+import org.quizly.quizly.core.application.BaseService;
+import org.quizly.quizly.core.domin.entity.Inquiry;
+import org.quizly.quizly.core.domin.repository.InquiryRepository;
+import org.quizly.quizly.core.exception.DomainException;
+import org.quizly.quizly.core.exception.error.BaseErrorCode;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class AdminReadInquiriesService implements BaseService<AdminReadInquiriesService.AdminReadInquiriesRequest, AdminReadInquiriesService.AdminReadInquiriesResponse> {
+
+    private final InquiryRepository inquiryRepository;
+
+    @Override
+    public AdminReadInquiriesResponse execute(AdminReadInquiriesRequest request) {
+
+        if(request == null || !request.isValid()){
+            return AdminReadInquiriesService.AdminReadInquiriesResponse.builder()
+                .success(false)
+                .errorCode(AdminReadInquiriesErrorCode.NOT_EXIST_REQUIRED_PARAMETER)
+                .build();
+        }
+
+        Sort sort = Sort.by(Sort.Direction.DESC,"createdAt");
+
+        List<Inquiry>inquiryList;
+
+        if(request.getStatus() == null){
+            inquiryList = inquiryRepository.findAllWithUser(sort);
+        }else{
+            inquiryList = inquiryRepository.findAllByStatusWithUser(request.getStatus(),sort);
+        }
+
+        return AdminReadInquiriesResponse.builder()
+            .success(true)
+            .inquiryList(inquiryList)
+            .build();
+
+    }
+
+
+    @Getter
+    @RequiredArgsConstructor
+    public enum AdminReadInquiriesErrorCode implements BaseErrorCode<DomainException> {
+        NOT_EXIST_REQUIRED_PARAMETER(HttpStatus.BAD_REQUEST, "요청 파라미터가 존재하지 않습니다.");
+
+        private final HttpStatus httpStatus;
+        private final String message;
+
+        @Override
+        public DomainException toException() {
+            return new DomainException(httpStatus, this);
+        }
+    }
+
+    @Getter
+    @Setter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @ToString
+    public static class AdminReadInquiriesRequest implements BaseRequest {
+
+        private Inquiry.Status status;
+
+
+        @Override
+        public boolean isValid() {
+            return true;
+        }
+    }
+
+    @Getter
+    @Setter
+    @SuperBuilder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @ToString
+    public static class AdminReadInquiriesResponse extends BaseResponse<AdminReadInquiriesService.AdminReadInquiriesErrorCode> {
+
+        private List<Inquiry> inquiryList;
+
+    }
+}

--- a/src/main/java/org/quizly/quizly/core/domin/repository/InquiryRepository.java
+++ b/src/main/java/org/quizly/quizly/core/domin/repository/InquiryRepository.java
@@ -2,10 +2,18 @@ package org.quizly.quizly.core.domin.repository;
 
 import org.quizly.quizly.core.domin.entity.Inquiry;
 import org.quizly.quizly.core.domin.entity.User;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface InquiryRepository extends JpaRepository<Inquiry,Long> {
     List<Inquiry> findAllByUser(User user);
+    @Query("SELECT i FROM Inquiry i JOIN FETCH i.user ")
+    List<Inquiry> findAllWithUser(Sort sort);
+
+    @Query("SELECT i FROM Inquiry i JOIN FETCH i.user WHERE i.status =:status")
+    List<Inquiry> findAllByStatusWithUser(@Param("status") Inquiry.Status status, Sort sort);
 }


### PR DESCRIPTION
- 연관 이슈
   - 이 PR이 해결하는 이슈: close #122  (병합 시 자동으로 이슈 닫힘)
   
- 작업 사항
    - QnA 에서 관리자가 사용자의 문의 전체를 조회할 수 있는 기능 추가
    - 전체 조회를 기본으로 정렬 기준[sortBy] (createAt,updatedAt) 에 따라 순서 방향[direction] 정렬(DESC,ASC)  가능 
    - 문의 상태[status] (WAITING, COMPLETED) 에 따라 정렬 가능
    - ADMIN 의 경우 조회 시 작성자의 이름, id 함께 조회 가능
- 테스트
    - Admin 계정으로만 조회 가능 여부 확인 완료