### PR TITLE
feat(#119): faq 조회 API 구현

### DIFF
--- a/src/main/java/org/quizly/quizly/configuration/SecurityConfig.java
+++ b/src/main/java/org/quizly/quizly/configuration/SecurityConfig.java
@@ -55,6 +55,7 @@ public class SecurityConfig {
         .authorizeHttpRequests(auth -> auth
             .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
             .requestMatchers(
+                "/faqs",
                 "/",
                 "/docs",
                 "/swagger-ui/**",

--- a/src/main/java/org/quizly/quizly/core/domin/repository/FaqRepository.java
+++ b/src/main/java/org/quizly/quizly/core/domin/repository/FaqRepository.java
@@ -1,7 +1,13 @@
 package org.quizly.quizly.core.domin.repository;
 
+import java.util.List;
 import org.quizly.quizly.core.domin.entity.Faq;
+import org.quizly.quizly.core.domin.entity.Faq.FaqCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FaqRepository extends JpaRepository<Faq, Long> {
+
+  List<Faq> findAllByDeletedFalseOrderByCreatedAt();
+
+  List<Faq> findByCategoryAndDeletedFalseOrderByCreatedAt(FaqCategory category);
 }

--- a/src/main/java/org/quizly/quizly/faq/controller/get/ReadFaqController.java
+++ b/src/main/java/org/quizly/quizly/faq/controller/get/ReadFaqController.java
@@ -1,0 +1,83 @@
+package org.quizly.quizly.faq.controller.get;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.quizly.quizly.configuration.swagger.ApiErrorCode;
+import org.quizly.quizly.core.application.BaseResponse;
+import org.quizly.quizly.core.exception.error.GlobalErrorCode;
+import org.quizly.quizly.faq.dto.response.ReadFaqResponse;
+import org.quizly.quizly.faq.dto.response.ReadFaqResponse.FaqCategoryGroup;
+import org.quizly.quizly.faq.dto.response.ReadFaqResponse.FaqDetail;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.quizly.quizly.core.domin.entity.Faq;
+import org.quizly.quizly.core.domin.entity.Faq.FaqCategory;
+import org.quizly.quizly.faq.service.ReadFaqService;
+import org.quizly.quizly.faq.service.ReadFaqService.ReadFaqErrorCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "FAQ", description = "FAQ")
+public class ReadFaqController {
+
+  private final ReadFaqService readFaqService;
+
+  @Operation(
+      summary = "FAQ 조회 API",
+      description = "FAQ 목록을 카테고리별로 조회합니다.\n\n"
+          + "- `category` 미입력 시 전체 반환\n"
+          + "- 카테고리: SERVICE_INTRO(서비스 소개), QUIZ_GENERATION(문제 생성), WRONG_ANSWER(오답 관리), TECH_SUPPORT(기술 지원)",
+      operationId = "/faqs"
+  )
+  @GetMapping("/faqs")
+  @ApiErrorCode(errorCodes = {GlobalErrorCode.class, ReadFaqErrorCode.class})
+  public ResponseEntity<ReadFaqResponse> readFaqs(
+      @RequestParam(required = false) FaqCategory category
+  ) {
+    ReadFaqService.ReadFaqResponse serviceResponse = readFaqService.execute(
+        ReadFaqService.ReadFaqRequest.builder()
+            .category(category)
+            .build()
+    );
+
+    if (serviceResponse == null || !serviceResponse.isSuccess()) {
+      Optional.ofNullable(serviceResponse)
+          .map(BaseResponse::getErrorCode)
+          .ifPresentOrElse(errorCode -> {
+            throw errorCode.toException();
+          }, () -> {
+            throw GlobalErrorCode.INTERNAL_ERROR.toException();
+          });
+    }
+
+    return ResponseEntity.ok(toResponse(serviceResponse));
+  }
+
+  private ReadFaqResponse toResponse(ReadFaqService.ReadFaqResponse serviceResponse) {
+    Map<FaqCategory, List<Faq>> groupedMap = serviceResponse.getFaqList().stream()
+        .collect(Collectors.groupingBy(Faq::getCategory));
+
+    List<FaqCategoryGroup> faqCategoryGroupList = Arrays.stream(FaqCategory.values())
+        .filter(groupedMap::containsKey)
+        .map(category -> new FaqCategoryGroup(
+            category,
+            category.getDescription(),
+            groupedMap.get(category).stream()
+                .map(faq -> new FaqDetail(faq.getId(), faq.getQuestion(), faq.getAnswer()))
+                .toList()
+        ))
+        .toList();
+
+    return ReadFaqResponse.builder()
+        .faqCategoryGroupList(faqCategoryGroupList)
+        .build();
+  }
+}

--- a/src/main/java/org/quizly/quizly/faq/dto/response/ReadFaqResponse.java
+++ b/src/main/java/org/quizly/quizly/faq/dto/response/ReadFaqResponse.java
@@ -1,0 +1,42 @@
+package org.quizly.quizly.faq.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+import org.quizly.quizly.core.application.BaseResponse;
+import org.quizly.quizly.core.domin.entity.Faq.FaqCategory;
+import org.quizly.quizly.core.exception.error.GlobalErrorCode;
+
+@Getter
+@NoArgsConstructor
+@ToString
+@SuperBuilder
+@Schema(description = "FAQ 목록 조회 응답")
+public class ReadFaqResponse extends BaseResponse<GlobalErrorCode> {
+
+  @Schema(description = "카테고리별 FAQ 그룹 목록")
+  private List<FaqCategoryGroup> faqCategoryGroupList;
+
+  @Schema(description = "카테고리별 FAQ 그룹")
+  public record FaqCategoryGroup(
+      @Schema(description = "FAQ 카테고리", example = "SERVICE_INTRO")
+      FaqCategory category,
+      @Schema(description = "카테고리 설명", example = "서비스 소개")
+      String description,
+      @Schema(description = "해당 카테고리의 FAQ 목록")
+      List<FaqDetail> faqDetailList
+  ) {}
+
+  @Schema(description = "FAQ 상세 정보")
+  public record FaqDetail(
+      @Schema(description = "FAQ ID", example = "1")
+      Long id,
+      @Schema(description = "질문", example = "Quizly는 어떤 서비스인가요?")
+      String question,
+      @Schema(description = "답변", example = "Quizly는 AI 기반 퀴즈 생성 서비스입니다.")
+      String answer
+  ) {}
+}

--- a/src/main/java/org/quizly/quizly/faq/service/ReadFaqService.java
+++ b/src/main/java/org/quizly/quizly/faq/service/ReadFaqService.java
@@ -1,0 +1,76 @@
+package org.quizly.quizly.faq.service;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import lombok.extern.log4j.Log4j2;
+import org.quizly.quizly.core.application.BaseRequest;
+import org.quizly.quizly.core.application.BaseResponse;
+import org.quizly.quizly.core.application.BaseService;
+import org.quizly.quizly.core.domin.entity.Faq;
+import org.quizly.quizly.core.domin.entity.Faq.FaqCategory;
+import org.quizly.quizly.core.domin.repository.FaqRepository;
+import org.quizly.quizly.core.exception.DomainException;
+import org.quizly.quizly.core.exception.error.BaseErrorCode;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Log4j2
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ReadFaqService implements BaseService<ReadFaqService.ReadFaqRequest, ReadFaqService.ReadFaqResponse> {
+
+  private final FaqRepository faqRepository;
+
+  @Override
+  public ReadFaqResponse execute(ReadFaqRequest request) {
+    if (request == null) {
+      log.error("[ReadFaqService] request is null - unexpected service logic error");
+      return ReadFaqResponse.builder()
+          .success(false)
+          .errorCode(ReadFaqErrorCode.NOT_EXIST_REQUIRED_PARAMETER)
+          .build();
+    }
+
+    List<Faq> faqList = request.getCategory() != null
+        ? faqRepository.findByCategoryAndDeletedFalseOrderByCreatedAt(request.getCategory())
+        : faqRepository.findAllByDeletedFalseOrderByCreatedAt();
+
+    return ReadFaqResponse.builder()
+        .faqList(faqList)
+        .build();
+  }
+
+  @Getter
+  @RequiredArgsConstructor
+  public enum ReadFaqErrorCode implements BaseErrorCode<DomainException> {
+
+    NOT_EXIST_REQUIRED_PARAMETER(HttpStatus.BAD_REQUEST, "필수 파라미터가 누락되었습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    @Override
+    public DomainException toException() {
+      return new DomainException(httpStatus, this);
+    }
+  }
+
+  @Getter
+  @Builder
+  public static class ReadFaqRequest implements BaseRequest {
+
+    private FaqCategory category;
+  }
+
+  @Getter
+  @SuperBuilder
+  public static class ReadFaqResponse extends BaseResponse<ReadFaqErrorCode> {
+
+    private List<Faq> faqList;
+  }
+}


### PR DESCRIPTION
- 연관 이슈
   - 이 PR이 해결하는 이슈: close #119
   
- 작업 사항
    - 로그인 여부와 관계없이 접근 가능한 FAQ 조회 API 구현
  - `category` 쿼리 파라미터로 특정 카테고리만 필터링 가능하며 미입력 시 전체 반환
  - #120 작업 예정인 soft delete(`deleted = false`) 조건 적용

- 테스트
    - 전체 조회 및 필터링 조회 테스트 완료하였습니다.

- 주의 사항
    - [선행 PR](https://github.com/Quizly-Team/backend/pull/121)(#118) 완료 이후 merge 예정