### PR TITLE
feat(#120): faq 삭제 API 구현

### DIFF
--- a/src/main/java/org/quizly/quizly/admin/controller/delete/DeleteFaqController.java
+++ b/src/main/java/org/quizly/quizly/admin/controller/delete/DeleteFaqController.java
@@ -1,0 +1,55 @@
+package org.quizly.quizly.admin.controller.delete;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.quizly.quizly.admin.service.DeleteFaqService;
+import org.quizly.quizly.admin.service.DeleteFaqService.DeleteFaqErrorCode;
+import org.quizly.quizly.configuration.swagger.ApiErrorCode;
+import org.quizly.quizly.core.application.BaseResponse;
+import org.quizly.quizly.core.exception.error.GlobalErrorCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "Admin", description = "관리자")
+public class DeleteFaqController {
+
+  private final DeleteFaqService deleteFaqService;
+
+  @Operation(
+      summary = "FAQ 삭제 API",
+      description = "관리자 전용 API로 FAQ를 삭제합니다.",
+      operationId = "/admin/faqs/{faqId}"
+  )
+  @DeleteMapping("/admin/faqs/{faqId}")
+  @PreAuthorize("hasRole('ADMIN')")
+  @ApiErrorCode(errorCodes = {GlobalErrorCode.class, DeleteFaqErrorCode.class})
+  public ResponseEntity<Void> deleteFaq(
+      @PathVariable Long faqId
+  ) {
+    DeleteFaqService.DeleteFaqResponse serviceResponse = deleteFaqService.execute(
+        DeleteFaqService.DeleteFaqRequest.builder()
+            .faqId(faqId)
+            .build()
+    );
+
+    if (serviceResponse == null || !serviceResponse.isSuccess()) {
+      Optional.ofNullable(serviceResponse)
+          .map(BaseResponse::getErrorCode)
+          .ifPresentOrElse(errorCode -> {
+            throw errorCode.toException();
+          }, () -> {
+            throw GlobalErrorCode.INTERNAL_ERROR.toException();
+          });
+    }
+
+    return ResponseEntity.noContent().build();
+  }
+}

--- a/src/main/java/org/quizly/quizly/admin/service/DeleteFaqService.java
+++ b/src/main/java/org/quizly/quizly/admin/service/DeleteFaqService.java
@@ -1,0 +1,78 @@
+package org.quizly.quizly.admin.service;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import lombok.extern.log4j.Log4j2;
+import org.quizly.quizly.admin.service.DeleteFaqService.DeleteFaqRequest;
+import org.quizly.quizly.admin.service.DeleteFaqService.DeleteFaqResponse;
+import org.quizly.quizly.core.application.BaseRequest;
+import org.quizly.quizly.core.application.BaseResponse;
+import org.quizly.quizly.core.application.BaseService;
+import org.quizly.quizly.core.domin.repository.FaqRepository;
+import org.quizly.quizly.core.exception.DomainException;
+import org.quizly.quizly.core.exception.error.BaseErrorCode;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class DeleteFaqService implements BaseService<DeleteFaqRequest, DeleteFaqResponse> {
+
+  private final FaqRepository faqRepository;
+
+  @Override
+  @Transactional
+  public DeleteFaqResponse execute(DeleteFaqRequest request) {
+    if (request == null || !request.isValid()) {
+      return DeleteFaqResponse.builder()
+          .success(false)
+          .errorCode(DeleteFaqErrorCode.NOT_FOUND_FAQ)
+          .build();
+    }
+
+    return faqRepository.findByIdAndDeletedFalse(request.getFaqId())
+        .map(faq -> {
+          faq.softDelete();
+          DeleteFaqResponse response = DeleteFaqResponse.builder().build();
+          return response;
+        })
+        .orElse(DeleteFaqResponse.builder()
+            .success(false)
+            .errorCode(DeleteFaqErrorCode.NOT_FOUND_FAQ)
+            .build());
+  }
+
+  @Getter
+  @RequiredArgsConstructor
+  public enum DeleteFaqErrorCode implements BaseErrorCode<DomainException> {
+
+    NOT_FOUND_FAQ(HttpStatus.NOT_FOUND, "FAQ를 찾을 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    @Override
+    public DomainException toException() {
+      return new DomainException(httpStatus, this);
+    }
+  }
+
+  @Getter
+  @Builder
+  public static class DeleteFaqRequest implements BaseRequest {
+    private Long faqId;
+
+    @Override
+    public boolean isValid() {
+      return faqId != null;
+    }
+  }
+
+  @Getter
+  @SuperBuilder
+  public static class DeleteFaqResponse extends BaseResponse<DeleteFaqErrorCode> {
+  }
+}

--- a/src/main/java/org/quizly/quizly/core/domin/entity/Faq.java
+++ b/src/main/java/org/quizly/quizly/core/domin/entity/Faq.java
@@ -42,4 +42,8 @@ public class Faq extends BaseEntity {
 
   @Column(columnDefinition = "TEXT", nullable = false)
   private String answer;
+
+  public void softDelete() {
+    setDeleted(true);
+  }
 }

--- a/src/main/java/org/quizly/quizly/core/domin/repository/FaqRepository.java
+++ b/src/main/java/org/quizly/quizly/core/domin/repository/FaqRepository.java
@@ -1,6 +1,7 @@
 package org.quizly.quizly.core.domin.repository;
 
 import java.util.List;
+import java.util.Optional;
 import org.quizly.quizly.core.domin.entity.Faq;
 import org.quizly.quizly.core.domin.entity.Faq.FaqCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -10,4 +11,6 @@ public interface FaqRepository extends JpaRepository<Faq, Long> {
   List<Faq> findAllByDeletedFalseOrderByCreatedAt();
 
   List<Faq> findByCategoryAndDeletedFalseOrderByCreatedAt(FaqCategory category);
+
+  Optional<Faq> findByIdAndDeletedFalse(Long id);
 }


### PR DESCRIPTION
- 연관 이슈
    - 이 PR이 해결하는 이슈: close #120
- 작업 사항
    - Admin 전용 FAQ Soft Delete API 구현 ( DB에서 실제 레코드를 삭제하지 않고 `deleted = true` 변경)
- 테스트
    - 삭제 후 조회하여 해당 FAQ 미포함 여부 테스트 완료 하였습니다.
    - 존재하지 않은 ID, 이미 삭제된 ID 요청 시 404 응답 확인 완료하였습니다.
- 주의 사항
    - [선행 PR](https://github.com/Quizly-Team/backend/pull/125)(#119) 완료 이후 merge 예정