### PR TITLE
feat(#127): 관리자 문의 답변 등록 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,10 @@ dependencies {
 	// Actuator
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
+	// mail
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
+	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+
 
 
 }

--- a/src/main/java/org/quizly/quizly/admin/controller/patch/AdminReplyInquiryController.java
+++ b/src/main/java/org/quizly/quizly/admin/controller/patch/AdminReplyInquiryController.java
@@ -1,0 +1,69 @@
+package org.quizly.quizly.admin.controller.patch;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.quizly.quizly.admin.dto.request.AdminReplyInquiryRequest;
+import org.quizly.quizly.admin.dto.response.AdminReplyInquiryResponse;
+import org.quizly.quizly.admin.service.AdminReplyInquiryService;
+import org.quizly.quizly.configuration.swagger.ApiErrorCode;
+import org.quizly.quizly.core.application.BaseResponse;
+import org.quizly.quizly.core.exception.error.GlobalErrorCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Optional;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "Admin", description = "관리자")
+public class AdminReplyInquiryController {
+
+    private final AdminReplyInquiryService adminReplyInquiryService;
+
+    @Operation(
+        summary = "관리자 문의 답변 등록 API",
+        description = "사용자가 등록한 문의에 대해 답변을 등록합니다.\n\n",
+        operationId = "/admin/inquiries"
+    )
+    @PatchMapping("/admin/inquiries/{inquiryId}")
+    @PreAuthorize("hasRole('ADMIN')")
+    @ApiErrorCode(errorCodes = {GlobalErrorCode.class, AdminReplyInquiryService.AdminReplyInquiryErrorCode.class})
+    public ResponseEntity<AdminReplyInquiryResponse> adminReplyInquiry(
+        @PathVariable Long inquiryId,
+        @RequestBody AdminReplyInquiryRequest request ) {
+
+        AdminReplyInquiryService.AdminReplyInquiryResponse serviceResponse = adminReplyInquiryService.execute(
+            AdminReplyInquiryService.AdminReplyInquiryRequest.builder()
+                .inquiryId(inquiryId)
+                .reply(request.getReply())
+                .build()
+        );
+
+        if (serviceResponse == null || !serviceResponse.isSuccess()) {
+            Optional.ofNullable(serviceResponse)
+                .map(BaseResponse::getErrorCode)
+                .ifPresentOrElse(errorCode -> {
+                    throw errorCode.toException();
+                }, () -> {
+                    throw GlobalErrorCode.INTERNAL_ERROR.toException();
+                });
+        }
+
+        return ResponseEntity.ok(toResponse(serviceResponse));
+    }
+
+    private AdminReplyInquiryResponse toResponse(AdminReplyInquiryService.AdminReplyInquiryResponse serviceResponse) {
+        return AdminReplyInquiryResponse.builder()
+            .inquiryId(serviceResponse.getInquiryId())
+            .title(serviceResponse.getTitle())
+            .reply(serviceResponse.getReply())
+            .repliedAt(serviceResponse.getRepliedAt())
+            .build();
+    }
+
+}

--- a/src/main/java/org/quizly/quizly/admin/dto/request/AdminReplyInquiryRequest.java
+++ b/src/main/java/org/quizly/quizly/admin/dto/request/AdminReplyInquiryRequest.java
@@ -1,0 +1,18 @@
+package org.quizly.quizly.admin.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.quizly.quizly.core.application.BaseRequest;
+
+@Getter
+@SuperBuilder
+@NoArgsConstructor
+@Schema(description = "관리자 문의 답변 등록 요청")
+public class AdminReplyInquiryRequest implements BaseRequest {
+
+    @Schema(description = "문의 답변 내용", example = "문의하신 내용에 대한 답변입니다.")
+    private String reply;
+
+}

--- a/src/main/java/org/quizly/quizly/admin/dto/response/AdminReplyInquiryResponse.java
+++ b/src/main/java/org/quizly/quizly/admin/dto/response/AdminReplyInquiryResponse.java
@@ -1,0 +1,28 @@
+package org.quizly.quizly.admin.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.quizly.quizly.core.application.BaseResponse;
+import org.quizly.quizly.core.exception.error.GlobalErrorCode;
+
+@Getter
+@SuperBuilder
+@NoArgsConstructor
+@Schema(description = "관리자 문의 답변 등록 응답")
+public class AdminReplyInquiryResponse extends BaseResponse<GlobalErrorCode> {
+
+    @Schema(description = "문의 ID", example = "1")
+    private Long inquiryId;
+
+    @Schema(description = "문의 제목", example = "로그인이 안 돼요.")
+    private String title;
+
+    @Schema(description = "등록된 답변 내용", example = "비밀번호 재설정을 시도해 보세요.")
+    private String reply;
+
+    @Schema(description = "답변 완료 시간", example = "2026-03-01 17:00:00")
+    private String repliedAt;
+
+}

--- a/src/main/java/org/quizly/quizly/admin/service/AdminReplyInquiryService.java
+++ b/src/main/java/org/quizly/quizly/admin/service/AdminReplyInquiryService.java
@@ -1,0 +1,131 @@
+package org.quizly.quizly.admin.service;
+
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+import lombok.extern.log4j.Log4j2;
+import org.quizly.quizly.core.application.BaseRequest;
+import org.quizly.quizly.core.application.BaseResponse;
+import org.quizly.quizly.core.application.BaseService;
+import org.quizly.quizly.core.domin.entity.Inquiry;
+import org.quizly.quizly.core.domin.entity.User;
+import org.quizly.quizly.core.domin.repository.InquiryRepository;
+import org.quizly.quizly.core.exception.DomainException;
+import org.quizly.quizly.core.exception.error.BaseErrorCode;
+import org.quizly.quizly.external.email.service.EmailService;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Log4j2
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AdminReplyInquiryService implements BaseService<AdminReplyInquiryService.AdminReplyInquiryRequest, AdminReplyInquiryService.AdminReplyInquiryResponse> {
+
+    private final InquiryRepository inquiryRepository;
+    private final EmailService emailService;
+
+    @Override
+    public AdminReplyInquiryResponse execute(AdminReplyInquiryRequest request) {
+
+        if(request == null || !request.isValid()){
+            return AdminReplyInquiryResponse.builder()
+                .success(false)
+                .errorCode(AdminReplyInquiryErrorCode.NOT_EXIST_REQUIRED_PARAMETER)
+                .build();
+        }
+
+        Inquiry inquiry = inquiryRepository.findById(request.getInquiryId())
+            .orElseThrow(AdminReplyInquiryErrorCode.NOT_FOUND_INQUIRY::toException);
+        inquiry.reply(request.getReply());
+
+        User user = inquiry.getUser();
+
+
+        if(user != null && user.getEmail() != null){
+            Map<String,Object> variables = new HashMap<>();
+            String nickname = user.getNickName() != null ? user.getNickName() : "고객";
+            String defaultTitle = String.format("%s님, 문의 하신 내용에 답변이 완료되었습니다.",nickname);
+            variables.put("title", defaultTitle);
+            variables.put("replyContent", inquiry.getReply());
+            variables.put("inquiryTitle", inquiry.getTitle());
+            variables.put("inquiryContent", inquiry.getContent());
+
+            EmailService.EmailRequest emailRequest = EmailService.EmailRequest
+                .builder()
+                .to(user.getEmail())
+                .subject("[Quizly]: 문의 답변 알림")
+                .templatePath("email/inquiry-reply")
+                .variables(variables)
+                .build();
+
+            EmailService.EmailResponse emailResponse = emailService.execute(emailRequest);
+            if (emailResponse == null || !emailResponse.isSuccess()) {
+                log.error("Failed to send reply notification email to: {}", user.getEmail());
+
+                return AdminReplyInquiryResponse.builder()
+                    .success(false)
+                    .errorCode(AdminReplyInquiryErrorCode.FAILED_TO_SEND_EMAIL)
+                    .build();
+            }
+        }
+
+        return AdminReplyInquiryResponse.builder()
+            .success(true)
+            .inquiryId(inquiry.getId())
+            .title(inquiry.getTitle())
+            .reply(inquiry.getReply())
+            .repliedAt(inquiry.getRepliedAt().format(java.time.format.DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")))
+            .build();
+
+    }
+
+    @Getter
+    @RequiredArgsConstructor
+    public enum AdminReplyInquiryErrorCode implements BaseErrorCode<DomainException> {
+        NOT_EXIST_REQUIRED_PARAMETER(HttpStatus.BAD_REQUEST, "요청 파라미터가 존재하지 않습니다."),
+        NOT_FOUND_INQUIRY(HttpStatus.NOT_FOUND, "문의를 찾을 수 없습니다."),
+        FAILED_TO_SEND_EMAIL(HttpStatus.INTERNAL_SERVER_ERROR, "답변 알림 메일 발송에 실패했습니다.");
+
+        private final HttpStatus httpStatus;
+        private final String message;
+
+        @Override
+        public DomainException toException() {
+            return new DomainException(httpStatus, this);
+        }
+    }
+
+    @Getter
+    @Setter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @ToString
+    public static class AdminReplyInquiryRequest implements BaseRequest {
+
+        private Long inquiryId;
+        private String reply;
+
+        @Override
+        public boolean isValid() {
+            return inquiryId != null && reply != null && !reply.isBlank();
+        }
+    }
+
+    @Getter
+    @Setter
+    @SuperBuilder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @ToString
+    public static class AdminReplyInquiryResponse extends BaseResponse<AdminReplyInquiryService.AdminReplyInquiryErrorCode> {
+        private Long inquiryId;
+        private String title;
+        private String reply;
+        private String repliedAt;
+    }
+}

--- a/src/main/java/org/quizly/quizly/core/domin/entity/Inquiry.java
+++ b/src/main/java/org/quizly/quizly/core/domin/entity/Inquiry.java
@@ -15,10 +15,10 @@ import java.time.LocalDateTime;
 @Table(name = "inquiry")
 public class Inquiry extends BaseEntity {
 
-    @Column(nullable = false)
+    @Column(name = "inquiry_title", nullable = false)
     private String title;
 
-    @Column(nullable = false)
+    @Column(name = "inquiry_content", nullable = false)
     private String content;
     @Getter
     @RequiredArgsConstructor
@@ -41,5 +41,12 @@ public class Inquiry extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
+
+    public void reply(String reply){
+        this.reply = reply;
+        this.status = Status.COMPLETED;
+        this.repliedAt = LocalDateTime.now();
+
+    }
 
 }

--- a/src/main/java/org/quizly/quizly/core/domin/repository/InquiryRepository.java
+++ b/src/main/java/org/quizly/quizly/core/domin/repository/InquiryRepository.java
@@ -5,6 +5,7 @@ import org.quizly.quizly.core.domin.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface InquiryRepository extends JpaRepository<Inquiry,Long> {
     List<Inquiry> findAllByUser(User user);

--- a/src/main/java/org/quizly/quizly/external/email/error/EmailErrorCode.java
+++ b/src/main/java/org/quizly/quizly/external/email/error/EmailErrorCode.java
@@ -1,0 +1,24 @@
+package org.quizly.quizly.external.email.error;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.quizly.quizly.core.exception.error.BaseErrorCode;
+import org.springframework.http.HttpStatus;
+@Getter
+@RequiredArgsConstructor
+public enum EmailErrorCode implements BaseErrorCode<EmailException> {
+    NOT_EXIST_EMAIL_REQUIRED_PARAMETER(HttpStatus.BAD_REQUEST, "EMAIL 요청 필수 파라미터가 존재하지 않습니다."),
+    FAILED_TO_SEND(HttpStatus.INTERNAL_SERVER_ERROR, "이메일 발송에 실패했습니다.");
+
+
+    private final HttpStatus httpStatus;
+
+    private final String message;
+
+    @Override
+    public EmailException toException() {
+        return new EmailException(message);
+    }
+
+}
+

--- a/src/main/java/org/quizly/quizly/external/email/error/EmailException.java
+++ b/src/main/java/org/quizly/quizly/external/email/error/EmailException.java
@@ -1,0 +1,17 @@
+package org.quizly.quizly.external.email.error;
+
+import org.springframework.http.HttpStatus;
+
+public class EmailException extends RuntimeException{
+
+    private HttpStatus httpStatus;
+
+    public EmailException(String message) {
+        super(message);
+    }
+
+    public EmailException(HttpStatus httpStatus, String message) {
+        super(message);
+        this.httpStatus = httpStatus;
+    }
+}

--- a/src/main/java/org/quizly/quizly/external/email/service/EmailService.java
+++ b/src/main/java/org/quizly/quizly/external/email/service/EmailService.java
@@ -1,0 +1,100 @@
+package org.quizly.quizly.external.email.service;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+import lombok.extern.log4j.Log4j2;
+import org.quizly.quizly.core.application.BaseRequest;
+import org.quizly.quizly.core.application.BaseResponse;
+import org.quizly.quizly.core.application.BaseService;
+import org.quizly.quizly.external.email.error.EmailErrorCode;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Map;
+
+@Log4j2
+@Service
+@RequiredArgsConstructor
+public class EmailService implements BaseService<EmailService.EmailRequest, EmailService.EmailResponse> {
+
+    private final JavaMailSender javaMailSender;
+    private final TemplateEngine templateEngine;
+
+    @Override
+    public EmailResponse execute(EmailRequest request) {
+        if(request == null || !request.isValid()){
+            return EmailResponse.builder()
+                .success(false)
+                .errorCode(EmailErrorCode.NOT_EXIST_EMAIL_REQUIRED_PARAMETER)
+                .build();
+        }
+        MimeMessage message = javaMailSender.createMimeMessage();
+        try{
+
+            MimeMessageHelper helper = new MimeMessageHelper(message,true,"UTF-8");
+
+            Context context = new Context();
+            if (request.getVariables() != null) {
+                request.getVariables().forEach(context::setVariable);
+            }
+
+            String htmlContent = templateEngine.process(request.getTemplatePath(),context);
+
+            helper.setTo(request.getTo());
+            helper.setSubject(request.getSubject());
+            helper.setText(htmlContent,true);
+
+
+            javaMailSender.send(message);
+            String now = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+
+            return EmailResponse.builder()
+                .success(true)
+                .to(request.getTo())
+                .sentAt(now)
+                .build();
+
+        }catch (MessagingException e){
+            log.error("Email Sending failed to : {}",request.getTo(),e);
+            return EmailResponse.builder()
+                .success(false)
+                .errorCode(EmailErrorCode.FAILED_TO_SEND)
+                .build();
+        }
+
+
+    }
+
+    @Getter
+    @Setter
+    @SuperBuilder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class EmailRequest implements BaseRequest {
+        private String to;
+        private String subject;
+        private String templatePath;
+        private Map<String,Object> variables;
+
+        @Override
+        public boolean isValid() {
+            return to != null && subject != null && templatePath != null;
+        }
+    }
+
+    @Getter
+    @Setter
+    @SuperBuilder
+    @NoArgsConstructor
+    public static class EmailResponse extends BaseResponse<EmailErrorCode> {
+        private String to;
+        private String sentAt;
+    }
+}

--- a/src/main/resources/templates/email/inquiry-reply.html
+++ b/src/main/resources/templates/email/inquiry-reply.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+</head>
+<body style="margin: 0; padding: 0; font-family: 'Pretendard', 'Apple SD Gothic Neo', sans-serif; background-color: #f8faf8;">
+<table align="center" border="0" cellpadding="0" cellspacing="0" width="100%" style="max-width: 600px; margin: 40px auto; background-color: #ffffff; border-radius: 20px; overflow: hidden; box-shadow: 0 10px 40px rgba(48, 161, 14, 0.1);">
+
+    <tr>
+        <td style="height: 8px; background-color: #30A10E;"></td>
+    </tr>
+
+    <tr>
+        <td style="padding: 40px 40px 10px 40px;">
+            <div style="color: #30A10E; font-size: 24px; font-weight: 900; letter-spacing: -1px;">Quizly</div>
+        </td>
+    </tr>
+
+    <tr>
+        <td style="padding: 0 40px 40px 40px;">
+            <h2 th:text="${title}" style="margin: 20px 0 30px 0; color: #111111; font-size: 20px; line-height: 1.5; font-weight: 700;">
+                사용자님, 문의하신 내용에 답변이 완료되었습니다.
+            </h2>
+
+            <div style="margin-bottom: 25px;">
+                <div style="font-size: 13px; font-weight: 700; color: #888; margin-bottom: 8px; letter-spacing: 0.5px;">내 문의</div>
+                <div style="padding: 20px; background-color: #f8f8f8; border-radius: 10px; border: 1px solid #eee;">
+                    <div th:text="${inquiryTitle}" style="font-weight: 700; color: #333; font-size: 15px; margin-bottom: 6px;">문의 제목</div>
+                    <div th:text="${inquiryContent}" style="color: #666; font-size: 14px; line-height: 1.6; white-space: pre-wrap;">문의 내용 본문</div>
+                </div>
+            </div>
+
+            <div style="margin-bottom: 40px;">
+                <div style="font-size: 13px; font-weight: 700; color: #30A10E; margin-bottom: 8px; letter-spacing: 0.5px;">문의 답변 내용 </div>
+                <div style="padding: 24px; background-color: #f4f9f3; border-radius: 10px; border: 1px solid #e1eee0; border-left: 5px solid #30A10E;">
+                    <div th:text="${replyContent}" style="color: #2d2d2d; font-size: 15px; line-height: 1.8; white-space: pre-wrap;">관리자 답변 내용</div>
+                </div>
+            </div>
+
+            <div style="text-align: center;">
+                <a href="https://quizly.co.kr" style="display: inline-block; padding: 16px 24px; background-color: #30A10E; color: #ffffff; text-decoration: none; border-radius: 12px; font-weight: 700; font-size: 16px;">
+                    Quizly 바로가기
+                </a>
+            </div>
+        </td>
+    </tr>
+
+    <tr>
+        <td style="padding: 30px 40px; background-color: #fafafa; border-top: 1px solid #f0f0f0; text-align: left;">
+            <p style="margin: 0; color: #999; font-size: 12px; line-height: 1.6;">
+                본 메일은 발신 전용 메일입니다. 추가 문의는 **고객센터**를 이용해 주세요.<br>
+                &copy; <span th:text="${#dates.year(#dates.createNow())}">2026</span> Quizly-Team. All rights reserved.
+            </p>
+        </td>
+    </tr>
+</table>
+</body>
+</html>


### PR DESCRIPTION
- 연관 이슈
   - 이 PR이 해결하는 이슈: close #127 (병합 시 자동으로 이슈 닫힘)
   
- 작업 사항
    - QnA 에서 관리자가 사용자의 문의에 대해 답변 등록
    - patch 매핑을 통해 일부 필드(reply,replatedAt, status)만 수정
    - smtp 설정과 javaMailSender를 통해 답변 알림 메일 발송 로직 추가
       - email 패키지를 별도로 두어 추후 다양한 상황에서 메일을 발송할 수 있도록 로직 추가
       - resources/templates/ 하에 메일 템플릿을 두어 발송 템플릿을 디자인 가능 ( 현재의 템플릿은 수정 가능성 높음)
 - 주의 사항
    - 현재 개인 smtp 로 설정해두어 공식 메일 기준으로 앱 비밀번호 설정 필요
    - application-prod.yml 변경 필요(github secret 반영 완료)
    - 템플릿 디자인 변경 필요
       
- 테스트
    - Admin 계정으로 답변 등록 및 메일 발송 확인