### PR TITLE
feat(#131): userInfo에서 role 추가 반환

### DIFF
--- a/src/main/java/org/quizly/quizly/account/controller/get/ReadUserInfoController.java
+++ b/src/main/java/org/quizly/quizly/account/controller/get/ReadUserInfoController.java
@@ -57,6 +57,7 @@ public class ReadUserInfoController {
         .email(serviceResponse.getEmail())
         .profileImageUrl(serviceResponse.getProfileImageUrl())
         .onboardingCompleted(serviceResponse.isOnboardingCompleted())
+        .role(serviceResponse.getRole())
         .build();
   }
 }

--- a/src/main/java/org/quizly/quizly/account/dto/response/ReadUserInfoResponse.java
+++ b/src/main/java/org/quizly/quizly/account/dto/response/ReadUserInfoResponse.java
@@ -6,6 +6,7 @@ import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 import org.quizly.quizly.core.application.BaseResponse;
+import org.quizly.quizly.core.domin.entity.User;
 import org.quizly.quizly.core.exception.error.GlobalErrorCode;
 
 @Getter
@@ -29,5 +30,8 @@ public class ReadUserInfoResponse extends BaseResponse<GlobalErrorCode> {
 
   @Schema(description = "온보딩 설문조사 여부", example = "true")
   private boolean onboardingCompleted;
+
+  @Schema(description = "역할", example = "USER")
+  private User.Role role;
 
 }

--- a/src/main/java/org/quizly/quizly/account/service/ReadUserInfoService.java
+++ b/src/main/java/org/quizly/quizly/account/service/ReadUserInfoService.java
@@ -61,6 +61,7 @@ public class ReadUserInfoService implements BaseService<ReadUserInfoRequest, Rea
         .email(user.getEmail())
         .profileImageUrl(user.getProfileImageUrl())
         .onboardingCompleted(user.isOnboardingCompleted())
+        .role(user.getRole())
         .success(true)
         .build();
   }
@@ -109,6 +110,7 @@ public class ReadUserInfoService implements BaseService<ReadUserInfoRequest, Rea
     private String email;
     private String profileImageUrl;
     private boolean onboardingCompleted;
+    private User.Role role;
   }
 
 }


### PR DESCRIPTION
- 연관 이슈
    - 이 PR이 해결하는 이슈: close #131

- 작업 사항 
    - 기존 구현 계획에서는 관리자 로그인을 별도로 두고 별도 Controller에서 관리할 계획이었으나, userInfo에서 role을 반환하도록 하여 관리자 검증이 끝나면 관리자 대시보드가 노출되도록 설계하는 것이 가장 기존 로직을 활용하는 방안이라고 판단하여 설계
    

- 테스트
    - 로컬 서버 테스트 완료
    - 프론트 임시 화면으로 USER, ADMIN 구분하여 관리자 페이지 노출 시키는 것 확인 완료 