### PR TITLE
fix(#135): 통계 쿼리 첫 번째 시도 필터링 버그 수정 (isFirst 추가)

### DIFF
--- a/src/main/java/org/quizly/quizly/account/service/ReadDailySummaryService.java
+++ b/src/main/java/org/quizly/quizly/account/service/ReadDailySummaryService.java
@@ -78,7 +78,7 @@ public class ReadDailySummaryService implements BaseService<ReadDailySummaryServ
 
   private List<ReadDailySummaryResponse.DailySummary> getTodayDailySummary(User user, LocalDate today) {
     return solveHistoryStatisticsRepository
-        .findDailySummaryByUserAndDate(user, today)
+        .findFirstAttemptsDailySummaryByUserAndDate(user, today)
         .stream()
         .map(summary -> new ReadDailySummaryResponse.DailySummary(
             summary.getDate(),

--- a/src/main/java/org/quizly/quizly/account/service/ReadHourlySummaryService.java
+++ b/src/main/java/org/quizly/quizly/account/service/ReadHourlySummaryService.java
@@ -91,7 +91,7 @@ public class ReadHourlySummaryService implements BaseService<ReadHourlySummarySe
   private Map<Integer, Integer> getTodayHourlyDataMap(User user, LocalDate today) {
     Map<Integer, Integer> map = new HashMap<>();
     List<SolveHistoryStatisticsRepository.HourlySummary> todayHourlyData =
-        solveHistoryStatisticsRepository.findHourlySummaryByUserAndDate(user, today);
+        solveHistoryStatisticsRepository.findFirstAttemptsHourlySummaryByUserAndDate(user, today);
 
     for (SolveHistoryStatisticsRepository.HourlySummary summary : todayHourlyData) {
       Integer hour = summary.getHourOfDay();

--- a/src/main/java/org/quizly/quizly/batch/step/AggregateSolveHourlySummaryStepConfig.java
+++ b/src/main/java/org/quizly/quizly/batch/step/AggregateSolveHourlySummaryStepConfig.java
@@ -58,7 +58,7 @@ public class AggregateSolveHourlySummaryStepConfig {
         LocalDate targetDate = LocalDate.parse(targetDateStr);
 
         List<HourlySummary> hourlySummaryList =
-            solveHistoryStatisticsRepository.findHourlySummaryByUserAndDate(user, targetDate);
+            solveHistoryStatisticsRepository.findFirstAttemptsHourlySummaryByUserAndDate(user, targetDate);
 
         List<SolveHourlySummary> existSolveHourlySummaryList =
             solveHourlySummaryRepository.findByUserAndDate(user, targetDate);

--- a/src/main/java/org/quizly/quizly/core/domin/entity/SolveHistory.java
+++ b/src/main/java/org/quizly/quizly/core/domin/entity/SolveHistory.java
@@ -6,7 +6,9 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -44,5 +46,9 @@ public class SolveHistory extends BaseEntity {
   @Column(nullable = true)
   private LocalDateTime submittedAt;
 
+  @Column(nullable = false)
+  @Builder.Default
+  @Setter(AccessLevel.NONE)
+  private boolean isFirst = true;
 
 }

--- a/src/main/java/org/quizly/quizly/core/domin/repository/SolveHistoryStatisticsRepository.java
+++ b/src/main/java/org/quizly/quizly/core/domin/repository/SolveHistoryStatisticsRepository.java
@@ -15,20 +15,13 @@ public interface SolveHistoryStatisticsRepository extends JpaRepository<SolveHis
 
   @Query("SELECT q.quizType as quizType, " +
       "COUNT(sh) as totalCount, " +
-      "SUM(CASE WHEN sh.isCorrect = true THEN 1 ELSE 0 END) as correctCount " +
+      "SUM(CASE WHEN sh.isCorrect = TRUE THEN 1 ELSE 0 END) as correctCount " +
       "FROM SolveHistory sh " +
       "JOIN sh.quiz q " +
       "WHERE sh.user = :user " +
       "AND sh.submittedAt >= :startDateTime " +
       "AND sh.submittedAt < :endDateTime " +
-      "AND (sh.quiz.id, sh.createdAt) IN (" +
-      "  SELECT sh2.quiz.id, MIN(sh2.createdAt) " +
-      "  FROM SolveHistory sh2 " +
-      "  WHERE sh2.user = :user " +
-      "  AND sh2.submittedAt >= :startDateTime " +
-      "  AND sh2.submittedAt < :endDateTime " +
-      "  GROUP BY sh2.quiz.id" +
-      ") " +
+      "AND sh.isFirst = TRUE " +
       "GROUP BY q.quizType")
   List<QuizTypeSummary> findFirstAttemptsByQuizTypeAndDateTimeRange(
       @Param("user") User user,
@@ -51,20 +44,13 @@ public interface SolveHistoryStatisticsRepository extends JpaRepository<SolveHis
   @Query("""
     SELECT q.topic as topic,
            COUNT(sh) as totalCount,
-           SUM(CASE WHEN sh.isCorrect = true THEN 1 ELSE 0 END) as correctCount
+           SUM(CASE WHEN sh.isCorrect = TRUE THEN 1 ELSE 0 END) as correctCount
     FROM SolveHistory sh
     JOIN sh.quiz q
     WHERE sh.user = :user
       AND sh.submittedAt >= :startDateTime
       AND sh.submittedAt < :endDateTime
-      AND (sh.quiz.id, sh.createdAt) IN (
-        SELECT sh2.quiz.id, MIN(sh2.createdAt)
-        FROM SolveHistory sh2
-        WHERE sh2.user = :user
-          AND sh2.submittedAt >= :startDateTime
-          AND sh2.submittedAt < :endDateTime
-        GROUP BY sh2.quiz.id
-      )
+      AND sh.isFirst = TRUE
     GROUP BY q.topic
   """)
   List<TopicSummary> findMonthlyTopicSummary(
@@ -86,18 +72,19 @@ public interface SolveHistoryStatisticsRepository extends JpaRepository<SolveHis
       "WHERE sh.user = :user " +
       "AND sh.submittedAt >= :startDateTime " +
       "AND sh.submittedAt < :endDateTime " +
+      "AND sh.isFirst = TRUE " +
       "GROUP BY CAST(sh.submittedAt AS LocalDate) " +
       "ORDER BY CAST(sh.submittedAt AS LocalDate)")
-  List<DailySummary> findDailySummaryByUserAndDateTimeRange(
+  List<DailySummary> findFirstAttemptsDailySummaryByUserAndDateTimeRange(
       @Param("user") User user,
       @Param("startDateTime") LocalDateTime startDateTime,
       @Param("endDateTime") LocalDateTime endDateTime
   );
 
-  default List<DailySummary> findDailySummaryByUserAndDate(User user, LocalDate date) {
+  default List<DailySummary> findFirstAttemptsDailySummaryByUserAndDate(User user, LocalDate date) {
     LocalDateTime startDateTime = date.atStartOfDay();
     LocalDateTime endDateTime = date.plusDays(1).atStartOfDay();
-    return findDailySummaryByUserAndDateTimeRange(user, startDateTime, endDateTime);
+    return findFirstAttemptsDailySummaryByUserAndDateTimeRange(user, startDateTime, endDateTime);
   }
 
   @Query("SELECT FUNCTION('HOUR', sh.submittedAt) as hourOfDay, " +
@@ -106,17 +93,18 @@ public interface SolveHistoryStatisticsRepository extends JpaRepository<SolveHis
       "WHERE sh.user = :user " +
       "AND sh.submittedAt >= :startDateTime " +
       "AND sh.submittedAt < :endDateTime " +
+      "AND sh.isFirst = TRUE " +
       "GROUP BY FUNCTION('HOUR', sh.submittedAt)")
-  List<HourlySummary> findHourlySummaryByUserAndDateTimeRange(
+  List<HourlySummary> findFirstAttemptsHourlySummaryByUserAndDateTimeRange(
       @Param("user") User user,
       @Param("startDateTime") LocalDateTime startDateTime,
       @Param("endDateTime") LocalDateTime endDateTime
   );
 
-  default List<HourlySummary> findHourlySummaryByUserAndDate(User user, LocalDate date) {
+  default List<HourlySummary> findFirstAttemptsHourlySummaryByUserAndDate(User user, LocalDate date) {
     LocalDateTime startDateTime = date.atStartOfDay();
     LocalDateTime endDateTime = date.plusDays(1).atStartOfDay();
-    return findHourlySummaryByUserAndDateTimeRange(user, startDateTime, endDateTime);
+    return findFirstAttemptsHourlySummaryByUserAndDateTimeRange(user, startDateTime, endDateTime);
   }
 
   interface DailySummary {

--- a/src/main/java/org/quizly/quizly/quiz/service/GradeMemberWrongQuizzesService.java
+++ b/src/main/java/org/quizly/quizly/quiz/service/GradeMemberWrongQuizzesService.java
@@ -121,6 +121,7 @@ public class GradeMemberWrongQuizzesService implements
             .userAnswer(userAnswer)
             .solveTime(solveTime)
             .submittedAt(LocalDateTime.now())
+            .isFirst(false)
             .build();
 
     solveHistoryRepository.save(solveHistory);


### PR DESCRIPTION
- 연관 이슈
    - 이 PR이 해결하는 이슈: close #135
        ([코드 리뷰](https://github.com/Quizly-Team/backend/pull/132#discussion_r2888993552) 중 발견한 이슈 사항)

- 작업 사항
    - `isFirst` (boolean) 필드 추가
    - 통계 쿼리에서 `sh.isFirst = TRUE` 사용하여 쿼리 단순회


- 테스트
    - 로컬 서버 테스트 완료 (더미 데이터를 바탕으로 통계 데이터 확인 완료)

- 주의 사항 (실서버 적용 시점 마이그레이션)
  - 실서버 배포 이후 배치 데이터 삭제 및 2~3월 재배치 실행 (admin api 사용 예정)
  - 기존 데이터 `is_first` 컬럼 초기값이 `false`로 채워지므로 배포 후 수동 실행 필요

    ```sql
    UPDATE solve_history sh
    JOIN (
        SELECT id, ROW_NUMBER() OVER (PARTITION BY user_id, quiz_id ORDER BY created_at) AS rn
        FROM solve_history
    ) ranked ON sh.id = ranked.id
    SET sh.is_first = (ranked.rn = 1);
    ```