### PR TITLE
feat(#138): 관리자 qna 페이지네이션 적용

### DIFF
--- a/src/main/java/org/quizly/quizly/admin/controller/get/AdminReadInquiriesController.java
+++ b/src/main/java/org/quizly/quizly/admin/controller/get/AdminReadInquiriesController.java
@@ -4,16 +4,18 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 import lombok.RequiredArgsConstructor;
+import org.quizly.quizly.admin.dto.request.AdminReadInquiriesRequest;
 import org.quizly.quizly.admin.dto.response.AdminReadInquiriesResponse;
 import org.quizly.quizly.admin.service.AdminReadInquiriesService;
 import org.quizly.quizly.configuration.swagger.ApiErrorCode;
 import org.quizly.quizly.core.application.BaseResponse;
 import org.quizly.quizly.core.domin.entity.Inquiry;
 import org.quizly.quizly.core.exception.error.GlobalErrorCode;
+import org.quizly.quizly.core.presentation.Pagination;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -27,18 +29,21 @@ public class AdminReadInquiriesController {
 
     @Operation(
         summary = "관리자 문의 전체 조회 API",
-        description = "사용자가 등록한 문의를 전체 조회합니다.\n\n",
+        description = "사용자가 등록한 문의를 전체 조회합니다.\n\n"
+            + "- `page`: 페이지 번호 (기본값 1)\n"
+            + "- `pageSize`: 그룹 단위 페이지 크기 (기본값 10)\n",
         operationId = "/admin/inquiries"
     )
     @GetMapping("/admin/inquiries")
     @PreAuthorize("hasRole('ADMIN')")
     @ApiErrorCode(errorCodes = {GlobalErrorCode.class, AdminReadInquiriesService.AdminReadInquiriesErrorCode.class})
     public ResponseEntity<AdminReadInquiriesResponse> adminReadInquiries(
-        @RequestParam(required = false) Inquiry.Status status
-        ){
+        @ModelAttribute AdminReadInquiriesRequest request)
+        {
         AdminReadInquiriesService.AdminReadInquiriesResponse serviceResponse = adminReadInquiriesService.execute(
             AdminReadInquiriesService.AdminReadInquiriesRequest.builder()
-                .status(status)
+                .status(request.getStatus())
+                .pageRequest(request.toPageRequest())
                 .build()
         );
         if (serviceResponse == null || !serviceResponse.isSuccess()) {
@@ -51,10 +56,12 @@ public class AdminReadInquiriesController {
                 });
         }
 
-        return ResponseEntity.ok(toResponse(serviceResponse.getInquiryList()));
+        return ResponseEntity.ok(toResponse(serviceResponse.getInquiryList(),serviceResponse.getPagination()));
     }
 
-    private AdminReadInquiriesResponse toResponse(List<Inquiry> inquiryList){
+    private AdminReadInquiriesResponse toResponse(
+        List<Inquiry> inquiryList,
+        Pagination pagination){
         List<AdminReadInquiriesResponse.AdminInquiryDetail> details = inquiryList.stream()
             .map(inquiry -> new AdminReadInquiriesResponse.AdminInquiryDetail(
                 inquiry.getId(),
@@ -71,6 +78,7 @@ public class AdminReadInquiriesController {
 
         return AdminReadInquiriesResponse.builder()
             .inquiryList(details)
+            .pagination(pagination)
             .build();
     }
 

--- a/src/main/java/org/quizly/quizly/admin/dto/request/AdminReadInquiriesRequest.java
+++ b/src/main/java/org/quizly/quizly/admin/dto/request/AdminReadInquiriesRequest.java
@@ -1,0 +1,15 @@
+package org.quizly.quizly.admin.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
+import org.quizly.quizly.core.domin.entity.Inquiry;
+import org.quizly.quizly.core.presentation.BasePaginationRequest;
+@Getter
+@Setter
+@Schema(description = "관리자 문의 조회 요청")
+public class AdminReadInquiriesRequest extends BasePaginationRequest {
+
+    @Schema(description = "문의 답변 상태", example = "WAITING")
+    private Inquiry.Status status;
+}

--- a/src/main/java/org/quizly/quizly/admin/dto/response/AdminReadInquiriesResponse.java
+++ b/src/main/java/org/quizly/quizly/admin/dto/response/AdminReadInquiriesResponse.java
@@ -7,6 +7,7 @@ import lombok.experimental.SuperBuilder;
 import org.quizly.quizly.core.application.BaseResponse;
 import org.quizly.quizly.core.domin.entity.Inquiry;
 import org.quizly.quizly.core.exception.error.GlobalErrorCode;
+import org.quizly.quizly.core.presentation.Pagination;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -18,6 +19,9 @@ import java.util.List;
 public class AdminReadInquiriesResponse extends BaseResponse<GlobalErrorCode> {
     @Schema(description = "전체 문의 목록")
     private List<AdminInquiryDetail> inquiryList;
+
+    @Schema(description = "페이지네이션 정보")
+    private Pagination pagination;
 
     @Schema(description = "전체 문의 목록 상세")
     public record AdminInquiryDetail(

--- a/src/main/java/org/quizly/quizly/admin/service/AdminReadInquiriesService.java
+++ b/src/main/java/org/quizly/quizly/admin/service/AdminReadInquiriesService.java
@@ -9,6 +9,10 @@ import org.quizly.quizly.core.domin.entity.Inquiry;
 import org.quizly.quizly.core.domin.repository.InquiryRepository;
 import org.quizly.quizly.core.exception.DomainException;
 import org.quizly.quizly.core.exception.error.BaseErrorCode;
+import org.quizly.quizly.core.presentation.Pagination;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -21,7 +25,7 @@ import java.util.List;
 public class AdminReadInquiriesService implements BaseService<AdminReadInquiriesService.AdminReadInquiriesRequest, AdminReadInquiriesService.AdminReadInquiriesResponse> {
 
     private final InquiryRepository inquiryRepository;
-
+    private static final String SORT_BY_LATEST = "createdAt";
     @Override
     public AdminReadInquiriesResponse execute(AdminReadInquiriesRequest request) {
 
@@ -31,20 +35,20 @@ public class AdminReadInquiriesService implements BaseService<AdminReadInquiries
                 .errorCode(AdminReadInquiriesErrorCode.NOT_EXIST_REQUIRED_PARAMETER)
                 .build();
         }
+        Pageable pageRequest = request.getPageRequest().withSort(Sort.by(Sort.Direction.DESC, SORT_BY_LATEST));
 
-        Sort sort = Sort.by(Sort.Direction.DESC,"createdAt");
-
-        List<Inquiry>inquiryList;
+        Page<Inquiry> inquiryPage;
 
         if(request.getStatus() == null){
-            inquiryList = inquiryRepository.findAllWithUser(sort);
+            inquiryPage = inquiryRepository.findAllWithUser(pageRequest);
         }else{
-            inquiryList = inquiryRepository.findAllByStatusWithUser(request.getStatus(),sort);
+            inquiryPage = inquiryRepository.findAllByStatusWithUser(request.getStatus(),pageRequest);
         }
 
         return AdminReadInquiriesResponse.builder()
             .success(true)
-            .inquiryList(inquiryList)
+            .inquiryList(inquiryPage.getContent())
+            .pagination(Pagination.getPaginationFromPage(inquiryPage))
             .build();
 
     }
@@ -73,11 +77,12 @@ public class AdminReadInquiriesService implements BaseService<AdminReadInquiries
     public static class AdminReadInquiriesRequest implements BaseRequest {
 
         private Inquiry.Status status;
+        private PageRequest pageRequest;
 
 
         @Override
         public boolean isValid() {
-            return true;
+            return pageRequest != null;
         }
     }
 
@@ -90,6 +95,7 @@ public class AdminReadInquiriesService implements BaseService<AdminReadInquiries
     public static class AdminReadInquiriesResponse extends BaseResponse<AdminReadInquiriesService.AdminReadInquiriesErrorCode> {
 
         private List<Inquiry> inquiryList;
+        private Pagination pagination;
 
     }
 }

--- a/src/main/java/org/quizly/quizly/core/domin/repository/InquiryRepository.java
+++ b/src/main/java/org/quizly/quizly/core/domin/repository/InquiryRepository.java
@@ -2,6 +2,8 @@ package org.quizly.quizly.core.domin.repository;
 
 import org.quizly.quizly.core.domin.entity.Inquiry;
 import org.quizly.quizly.core.domin.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -12,9 +14,11 @@ import java.util.Optional;
 
 public interface InquiryRepository extends JpaRepository<Inquiry,Long> {
     List<Inquiry> findAllByUser(User user);
-    @Query("SELECT i FROM Inquiry i JOIN FETCH i.user ")
-    List<Inquiry> findAllWithUser(Sort sort);
+    @Query(value = "SELECT i FROM Inquiry i JOIN FETCH i.user",
+        countQuery = "SELECT count(i) FROM Inquiry i")
+    Page<Inquiry> findAllWithUser(Pageable pageable);
 
-    @Query("SELECT i FROM Inquiry i JOIN FETCH i.user WHERE i.status =:status")
-    List<Inquiry> findAllByStatusWithUser(@Param("status") Inquiry.Status status, Sort sort);
+    @Query(value = "SELECT i FROM Inquiry i JOIN FETCH i.user WHERE i.status = :status",
+        countQuery = "SELECT count(i) FROM Inquiry i WHERE i.status = :status")
+    Page<Inquiry> findAllByStatusWithUser(@Param("status") Inquiry.Status status, Pageable pageable);
 }


### PR DESCRIPTION
- 연관 이슈
    - 이 PR이 해결하는 이슈: close #138
        
- 작업 사항
    - 문제 풀이 조회에서 사용하고 있는 페이지네이션과 동일한 방식으로 관리자 QnA 조회에 적용
    - BasePaginationRequest 활용하여 AdminReadInquiriesRequest 추가
   


- 테스트
   - inquiry 20개 이상 추가 후 10개씩 반환되는 것 확인, 기본 내림차순 및 status = WAITING/COMPLETED 별로 나오는 것 확인

- 주의 사항
   - 클라이언트(프론트엔드) 환경에서도 해당 페이지네이션 적용되도록 수정 필요 