### PR TITLE
feat(#150): mock 데이터 저장 추가

### DIFF
--- a/src/main/java/org/quizly/quizly/core/domin/entity/MockExam.java
+++ b/src/main/java/org/quizly/quizly/core/domin/entity/MockExam.java
@@ -1,0 +1,27 @@
+package org.quizly.quizly.core.domin.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+import org.quizly.quizly.core.domin.shared.BaseEntity;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@SuperBuilder
+@Entity
+@Table(name = "mock_exam")
+public class MockExam extends BaseEntity {
+
+
+    @Column(columnDefinition = "LONGTEXT", nullable = false)
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+}

--- a/src/main/java/org/quizly/quizly/core/domin/repository/MockExamRepository.java
+++ b/src/main/java/org/quizly/quizly/core/domin/repository/MockExamRepository.java
@@ -1,0 +1,7 @@
+package org.quizly.quizly.core.domin.repository;
+
+import org.quizly.quizly.core.domin.entity.MockExam;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MockExamRepository extends JpaRepository<MockExam,Long> {
+}

--- a/src/main/java/org/quizly/quizly/mock/controller/post/CreateMemberMockExamController.java
+++ b/src/main/java/org/quizly/quizly/mock/controller/post/CreateMemberMockExamController.java
@@ -14,7 +14,6 @@ import org.quizly.quizly.mock.dto.response.CreateMemberMockExamResponse;
 import org.quizly.quizly.mock.dto.response.CreateMemberMockExamResponse.MockExamDetail;
 import org.quizly.quizly.mock.service.CreateMemberMockExamService;
 import org.quizly.quizly.oauth.UserPrincipal;
-import org.quizly.quizly.quiz.service.CreateMemberQuizzesService.CreateMemberQuizzesErrorCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -34,7 +33,7 @@ public class CreateMemberMockExamController {
       operationId = "/mock/member"
   )
   @PostMapping("/mock/member")
-  @ApiErrorCode(errorCodes = {GlobalErrorCode.class, CreateMemberQuizzesErrorCode.class})
+  @ApiErrorCode(errorCodes = {GlobalErrorCode.class, CreateMemberMockExamService.CreateMemberMockExamErrorCode.class})
   public ResponseEntity<CreateMemberMockExamResponse> createMemberMockExam(
       @RequestBody CreateMemberMockExamRequest request,
       @AuthenticationPrincipal UserPrincipal userPrincipal) {

--- a/src/main/java/org/quizly/quizly/mock/service/CreateMemberMockExamService.java
+++ b/src/main/java/org/quizly/quizly/mock/service/CreateMemberMockExamService.java
@@ -4,6 +4,9 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,9 +15,13 @@ import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 import lombok.extern.log4j.Log4j2;
+import org.quizly.quizly.account.service.ReadUserService;
 import org.quizly.quizly.core.application.BaseRequest;
 import org.quizly.quizly.core.application.BaseResponse;
 import org.quizly.quizly.core.application.BaseService;
+import org.quizly.quizly.core.domin.entity.MockExam;
+import org.quizly.quizly.core.domin.entity.User;
+import org.quizly.quizly.core.domin.repository.MockExamRepository;
 import org.quizly.quizly.core.exception.DomainException;
 import org.quizly.quizly.core.exception.error.BaseErrorCode;
 import org.quizly.quizly.core.util.AsyncTaskUtil;
@@ -28,7 +35,6 @@ import org.quizly.quizly.mock.service.CreateMockQuizService.CreateMockQuizRespon
 import org.quizly.quizly.oauth.UserPrincipal;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
-
 @Log4j2
 @Service
 @RequiredArgsConstructor
@@ -36,6 +42,9 @@ public class CreateMemberMockExamService implements
     BaseService<CreateMemberMockExamRequest, CreateMemberMockExamResponse> {
 
   private final CreateMockQuizService createMockQuizService;
+  private final ReadUserService readUserService;
+  private final MockExamRepository mockExamRepository;
+  private final ObjectMapper objectMapper;
 
   private static final int MIN_QUIZ_COUNT = 10;
   private static final int MAX_QUIZ_COUNT = 30;
@@ -53,6 +62,19 @@ public class CreateMemberMockExamService implements
               .errorCode(CreateMemberMockExamErrorCode.NOT_EXIST_REQUIRED_PARAMETER)
               .build();
     }
+    ReadUserService.ReadUserResponse readUserResponse = readUserService.execute(
+        ReadUserService.ReadUserRequest.builder()
+            .userPrincipal(request.getUserPrincipal())
+            .build()
+    );
+
+    if (!readUserResponse.isSuccess()) {
+      return CreateMemberMockExamResponse.builder()
+          .success(false)
+          .errorCode(CreateMemberMockExamErrorCode.NOT_FOUND_USER)
+          .build();
+    }
+    User user = readUserResponse.getUser();
 
     String plainText = request.getPlainText();
     List<String> chunkList = TextProcessingUtil.createChunkList(
@@ -96,12 +118,43 @@ public class CreateMemberMockExamService implements
     postProcessingFindMatch(generatedMockExamResponseList);
     postProcessingFindCorrectAndIncorrect(generatedMockExamResponseList);
 
+    saveMockExam(generatedMockExamResponseList,user);
+
     return CreateMemberMockExamResponse.builder()
         .quizList(generatedMockExamResponseList)
         .success(true)
         .build();
   }
+  private void saveMockExam(
+      List<GeneratedMockExamResponse> generatedMockExamResponseList,
+      User user
+  ) {
+    try {
+      String content = objectMapper.writeValueAsString(generatedMockExamResponseList);
 
+      MockExam mockExam = MockExam.builder()
+          .content(content)
+          .user(user)
+          .build();
+
+      mockExamRepository.saveAndFlush(mockExam);
+
+    } catch (JsonProcessingException e) {
+      log.warn(
+          "[CreateMemberMockExamService] Failed to serialize mock exam result. userId={}, generatedQuizCount={}",
+          user.getId(),
+          generatedMockExamResponseList.size(),
+          e
+      );
+    } catch (Exception e) {
+      log.warn(
+          "[CreateMemberMockExamService] Failed to save mock exam. userId={}, generatedQuizCount={}",
+          user.getId(),
+          generatedMockExamResponseList.size(),
+          e
+      );
+    }
+  }
   private void postProcessingChunkList(List<String> chunkList) {
     if (chunkList.size() <= 1) {
       return;
@@ -224,7 +277,8 @@ public class CreateMemberMockExamService implements
     NOT_EXIST_PROVIDER_ID(HttpStatus.BAD_REQUEST, "Provider ID가 존재하지 않습니다."),
     INVALID_QUIZ_COUNT_RANGE(HttpStatus.BAD_REQUEST, "모의고사 문제 개수는 10개 이상 30개 이하여야 합니다."),
     FAILED_CREATE_CHUNK(HttpStatus.INTERNAL_SERVER_ERROR, "사용자 입력을 chunk 단위 분리에 실패하였습니다."),
-    OPENAI_MOCK_EXAM_GENERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "OPENAI 서버에서 모의고사 생성에 실패하였습니다.");
+    OPENAI_MOCK_EXAM_GENERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "OPENAI 서버에서 모의고사 생성에 실패하였습니다."),
+    NOT_FOUND_USER(HttpStatus.NOT_FOUND, "유저를 찾을 수 없습니다.");
 
     private final HttpStatus httpStatus;
 


### PR DESCRIPTION
- 연관 이슈
    - 이 PR이 해결하는 이슈: #150

- 작업 사항
    - mock 데이터 생성 결과를 저장하기 위해 mock entity, repository 추가 및 save 로직 추가
    - 생성 데이터 기록이 목적이기 때문에 list 결과를 그대로 content로 저장하되 @Lob과 LONGTEXT 선언으로 긴 용량도 저장할 수 있도록 설
- 테스트
    - 로컬 서버 테스트 완료 