### PR TITLE
feat(#152): 회원가입 시 slack 알림 추가

### DIFF
--- a/src/main/java/org/quizly/quizly/batch/message/BatchFailureNotificationMessage.java
+++ b/src/main/java/org/quizly/quizly/batch/message/BatchFailureNotificationMessage.java
@@ -1,5 +1,6 @@
 package org.quizly.quizly.batch.message;
 
+import org.quizly.quizly.core.notification.NotificationChannel;
 import org.quizly.quizly.core.notification.NotificationMessage;
 
 public class BatchFailureNotificationMessage implements NotificationMessage {
@@ -26,5 +27,10 @@ public class BatchFailureNotificationMessage implements NotificationMessage {
     @Override
     public String body() {
         return "job=" + jobName + "\nreason=" + reason + "\nstep=" + step + "\nparameters=" + parameters;
+    }
+
+    @Override
+    public NotificationChannel channel() {
+        return NotificationChannel.BATCH;
     }
 }

--- a/src/main/java/org/quizly/quizly/core/notification/NotificationChannel.java
+++ b/src/main/java/org/quizly/quizly/core/notification/NotificationChannel.java
@@ -1,0 +1,6 @@
+package org.quizly.quizly.core.notification;
+
+public enum NotificationChannel{
+    BATCH,
+    SIGNUP
+}

--- a/src/main/java/org/quizly/quizly/core/notification/NotificationMessage.java
+++ b/src/main/java/org/quizly/quizly/core/notification/NotificationMessage.java
@@ -1,6 +1,8 @@
 package org.quizly.quizly.core.notification;
 
+
 public interface NotificationMessage {
     String title();
     String body();
+    NotificationChannel channel();
 }

--- a/src/main/java/org/quizly/quizly/external/slack/service/SlackNotificationService.java
+++ b/src/main/java/org/quizly/quizly/external/slack/service/SlackNotificationService.java
@@ -11,6 +11,7 @@ import org.quizly.quizly.core.application.BaseResponse;
 import org.quizly.quizly.core.application.BaseService;
 import org.quizly.quizly.core.exception.DomainException;
 import org.quizly.quizly.core.exception.error.BaseErrorCode;
+import org.quizly.quizly.core.notification.NotificationChannel;
 import org.quizly.quizly.core.notification.NotificationMessage;
 import org.quizly.quizly.core.notification.NotificationProvider;
 import org.quizly.quizly.external.slack.dto.Request.SlackRequest;
@@ -27,8 +28,11 @@ import org.springframework.web.client.RestTemplate;
 @RequiredArgsConstructor
 public class SlackNotificationService implements NotificationProvider, BaseService<SlackNotificationService.NotificationRequest, SlackNotificationService.NotificationResponse> {
 
-    @Value("${notification.slack.webhook-url}")
-    private String webhookUrl;
+    @Value("${notification.slack.batch.webhook-url}")
+    private String batchWebhookUrl;
+
+    @Value("${notification.slack.signup.webhook-url}")
+    private String signupWebhookUrl;
 
     private final RestTemplate restTemplate;
     private final Environment environment;
@@ -39,7 +43,16 @@ public class SlackNotificationService implements NotificationProvider, BaseServi
             return;
         }
         String text = format(message);
-        this.execute(new NotificationRequest(text));
+        String webhookUrl = getWebhookUrl(message.channel());
+        this.execute(new NotificationRequest(text,webhookUrl));
+    }
+
+    private String getWebhookUrl(NotificationChannel channel) {
+        return switch (channel) {
+            case SIGNUP -> signupWebhookUrl;
+            case BATCH -> batchWebhookUrl;
+            default -> throw new IllegalArgumentException("지원하지 않는 알림 채널입니다: " + channel);
+        };
     }
 
     private String format(NotificationMessage message) {
@@ -55,7 +68,7 @@ public class SlackNotificationService implements NotificationProvider, BaseServi
 
         try {
             SlackRequest slackRequest = new SlackRequest(request.getMessage());
-            restTemplate.postForEntity(webhookUrl, slackRequest, String.class);
+            restTemplate.postForEntity(request.getWebhookUrl(), slackRequest, String.class);
 
             return NotificationResponse.builder()
                 .success(true)
@@ -87,10 +100,13 @@ public class SlackNotificationService implements NotificationProvider, BaseServi
     @NoArgsConstructor
     public static class NotificationRequest implements BaseRequest {
         private String message;
+        private String webhookUrl;
 
         @Override
         public boolean isValid() {
-            return message != null && !message.isBlank();
+
+            return message != null && !message.isBlank()
+                && webhookUrl !=null && !webhookUrl.isBlank();
         }
     }
 

--- a/src/main/java/org/quizly/quizly/oauth/message/SignupNotificationMessage.java
+++ b/src/main/java/org/quizly/quizly/oauth/message/SignupNotificationMessage.java
@@ -1,0 +1,31 @@
+package org.quizly.quizly.oauth.message;
+
+import org.quizly.quizly.core.domin.entity.User;
+import org.quizly.quizly.core.notification.NotificationChannel;
+import org.quizly.quizly.core.notification.NotificationMessage;
+
+public class SignupNotificationMessage implements NotificationMessage {
+    private final User user;
+
+    public SignupNotificationMessage(User user) {
+        this.user = user;
+    }
+
+    @Override
+    public String title() {
+        return "회원 가입";
+    }
+
+    @Override
+    public String body() {
+        return "새로운 유저가 가입했습니다!\n"
+            + "닉네임: " + user.getNickName() + "\n"
+            + "가입 시각: " + user.getCreatedAt() + "\n"
+            + "provider: " + user.getProvider();
+    }
+
+    @Override
+    public NotificationChannel channel() {
+        return NotificationChannel.SIGNUP;
+    }
+}

--- a/src/main/java/org/quizly/quizly/oauth/service/OAuth2LoginUserService.java
+++ b/src/main/java/org/quizly/quizly/oauth/service/OAuth2LoginUserService.java
@@ -7,10 +7,12 @@ import org.quizly.quizly.core.domin.entity.User;
 import org.quizly.quizly.core.domin.entity.User.Provider;
 import org.quizly.quizly.core.domin.entity.User.Role;
 import org.quizly.quizly.core.domin.repository.UserRepository;
+import org.quizly.quizly.core.notification.NotificationProvider;
 import org.quizly.quizly.oauth.UserPrincipal;
 import org.quizly.quizly.oauth.dto.response.KakaoUserInfo;
 import org.quizly.quizly.oauth.dto.response.NaverUserInfo;
 import org.quizly.quizly.oauth.dto.response.OAuth2UserInfo;
+import org.quizly.quizly.oauth.message.SignupNotificationMessage;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
@@ -23,6 +25,7 @@ import org.springframework.stereotype.Service;
 public class OAuth2LoginUserService extends DefaultOAuth2UserService {
 
   private final UserRepository userRepository;
+  private final NotificationProvider notificationProvider;
 
   @Override
   public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
@@ -75,8 +78,14 @@ public class OAuth2LoginUserService extends DefaultOAuth2UserService {
     userEntity.setName(oAuth2UserInfo.getNickname());
     userEntity.setNickName(oAuth2UserInfo.getNickname());
     userEntity.setRole(Role.USER);
-    userRepository.save(userEntity);
-    return userEntity;
+    User savedUser = userRepository.save(userEntity);
+
+    try{
+      notificationProvider.send(new SignupNotificationMessage(savedUser));
+    }catch (Exception e) {
+      log.warn("[OAuth2LoginUserService] 회원가입 슬랙 알림 전송 실패. userId: {}", savedUser.getId(), e);
+    }
+    return savedUser;
   }
 
   private User updateUser(User user, OAuth2UserInfo oAuth2UserInfo) {


### PR DESCRIPTION
- 연관 이슈
    - 이 PR이 해결하는 이슈: #152

- 작업 사항
    - 회원가입시 save 이후 slack 알림 발송되도록 구현
    - 배치 알림과 구별하기 위한 NotificationChannel enum추가 및 배치, 회원가입 로직에서 각 개별 webhookurl 전달될 수 있도록 설계 하여 구분하여 전송
   
- 테스트
    - 로컬에서 보낼 수 있도록 임시 설정 이후 최초 회원가입 시 알림 테스트 완료 
<img width="301" height="114" alt="image" src="https://github.com/user-attachments/assets/80d28ee7-36d7-4162-83b8-3caeefbdf915" />

- 유의 사항
  - application.yml 변화 확인 및 병합 이후 업데이트 필요