### PR TITLE
ci(#154): 실서버 배포 환경 NCP에서 OCI로 이관

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,4 +1,4 @@
-name: Quizly Deploy (NCP)
+name: Quizly Main Deploy (OCI)
 
 on:
   push:
@@ -27,47 +27,43 @@ jobs:
           chmod +x gradlew
           ./gradlew clean build -x test
 
-      - name: Transfer Config to Server
-        uses: appleboy/scp-action@master
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
         with:
-          host: ${{ secrets.NCP_HOST_PROD }}
-          username: ${{ secrets.NCP_USERNAME_PROD }}
-          password: ${{ secrets.NCP_PASSWORD_PROD }}
-          port: ${{ secrets.NCP_PORT_PROD }}
-          source: "./src/main/resources/application.yml"
-          target: "/root/quizly-server"
-          strip_components: 4
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Transfer Script to Server
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build & Push to GHCR
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/arm64
+          push: true
+          tags: ghcr.io/quizly-team/backend:${{ github.sha }}
+
+      - name: Transfer Deploy Script to Server
         uses: appleboy/scp-action@master
         with:
-          host: ${{ secrets.NCP_HOST_PROD }}
-          username: ${{ secrets.NCP_USERNAME_PROD }}
-          password: ${{ secrets.NCP_PASSWORD_PROD }}
-          port: ${{ secrets.NCP_PORT_PROD }}
+          host: ${{ secrets.OCI_HOST_PROD }}
+          username: ${{ secrets.OCI_USERNAME_PROD }}
+          key: ${{ secrets.OCI_SSH_KEY_PROD }}
+          port: 22
           source: "./deploy-prod.sh"
-          target: "/root/quizly-server"
-
-      - name: Build & Push to NCR
-        run: |
-          echo "Logging into NCR..."
-          docker login ${{ secrets.NCP_CONTAINER_REGISTRY }} -u ${{ secrets.NCP_ACCESS_KEY }} -p ${{ secrets.NCP_SECRET_KEY }}
-          
-          echo "Building Image..."
-          docker build -t ${{ secrets.NCP_CONTAINER_REGISTRY }}/quizly:${{ github.sha }} .
-          
-          echo "Pushing Image..."
-          docker push ${{ secrets.NCP_CONTAINER_REGISTRY }}/quizly:${{ github.sha }}
+          target: "/home/ubuntu/quizly-server"
 
       - name: Execute Deploy Script
         uses: appleboy/ssh-action@master
         with:
-          host: ${{ secrets.NCP_HOST_PROD }}
-          username: ${{ secrets.NCP_USERNAME_PROD }}
-          password: ${{ secrets.NCP_PASSWORD_PROD }}
-          port: ${{ secrets.NCP_PORT_PROD }}
+          host: ${{ secrets.OCI_HOST_PROD }}
+          username: ${{ secrets.OCI_USERNAME_PROD }}
+          key: ${{ secrets.OCI_SSH_KEY_PROD }}
+          port: 22
           script: |
-            docker login ${{ secrets.NCP_CONTAINER_REGISTRY }} -u ${{ secrets.NCP_ACCESS_KEY }} -p ${{ secrets.NCP_SECRET_KEY }}
-            cd /root/quizly-server
+            echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+            cd /home/ubuntu/quizly-server
             chmod +x deploy-prod.sh
-            ./deploy-prod.sh ${{ secrets.NCP_CONTAINER_REGISTRY }}/quizly ${{ github.sha }}
+            ./deploy-prod.sh ghcr.io/quizly-team/backend ${{ github.sha }}

--- a/deploy-prod.sh
+++ b/deploy-prod.sh
@@ -29,8 +29,9 @@ echo "> 타겟 포트: $TARGET_PORT"
 docker pull $FULL_IMAGE_NAME
 docker rm -f "$TARGET_NAME" 2>/dev/null || true
 
-docker run -d --name "$TARGET_NAME" -p "${TARGET_PORT}:8080" \
-  -v /root/quizly-server/application.yml:/application.yml \
+docker run -d --name "$TARGET_NAME" \
+  --network host \
+  -e SERVER_PORT=${TARGET_PORT} \
   -v "$LOG_DIR":/logs \
   --memory="1280m" \
   "$FULL_IMAGE_NAME"


### PR DESCRIPTION
- 연관 이슈
    - 이 PR이 해결하는 이슈: #154

- 작업 사항
    - 컨테이너 레지스트리 NCR → GHCR ([GHCR 이미지 패키지](https://github.com/Quizly-Team/backend/pkgs/container/backend))
    - 서버 접속 방식 변경 (password → SSH key)
    - 배포 스크립트(`deploy-prod.sh`) 수정

- 테스트
    - test 브랜치에서 CICD 성공 후 서버 정상 동작 확인 완료

- 주의 사항 및 참고사항
    - [x] 해당 PR은 `main`에만 적용되면 되는 사항으로 `main` merge 완료 후 `dev`를 `main` 기준으로 rebase하여 정렬 예정 -> `26.6.29 12:28` 완료
    - Actions secrets 추가 완료