### PR TITLE
refactor(#163): 다중 Origin 환경에서 OAuth2 로그인 콜백 URI 분기 처리

### DIFF
--- a/src/main/java/org/quizly/quizly/configuration/CorsMvcConfig.java
+++ b/src/main/java/org/quizly/quizly/configuration/CorsMvcConfig.java
@@ -11,9 +11,6 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 @Configuration
 public class CorsMvcConfig {
 
-    @Value("${custom.oauth2.front-redirect-url}")
-    private String frontRedirectUrl;
-
     @Value("${cors.allowed-origins}")
     private List<String> corsAllowedOrigins;
 
@@ -22,10 +19,7 @@ public class CorsMvcConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
 
-        List<String> allowedOrigins = new java.util.ArrayList<>(corsAllowedOrigins);
-        allowedOrigins.add(frontRedirectUrl);
-
-        configuration.setAllowedOrigins(allowedOrigins);
+        configuration.setAllowedOrigins(corsAllowedOrigins);
         configuration.setAllowedMethods(List.of("*"));
         configuration.setAllowedHeaders(List.of("*"));
         configuration.setAllowCredentials(true);

--- a/src/main/java/org/quizly/quizly/configuration/SecurityConfig.java
+++ b/src/main/java/org/quizly/quizly/configuration/SecurityConfig.java
@@ -1,11 +1,15 @@
 package org.quizly.quizly.configuration;
 
 import jakarta.servlet.DispatcherType;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.quizly.quizly.jwt.JwtAuthenticationFilter;
 import org.quizly.quizly.jwt.error.JwtAuthenticationEntryPoint;
+import org.quizly.quizly.oauth.CookieAuthorizationRequestRepository;
+import org.quizly.quizly.oauth.CustomAuthorizationRequestResolver;
 import org.quizly.quizly.oauth.OAuth2LoginSuccessHandler;
 import org.quizly.quizly.oauth.service.OAuth2LoginUserService;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -14,6 +18,7 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfigurationSource;
@@ -29,6 +34,11 @@ public class SecurityConfig {
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
     private final CorsConfigurationSource corsConfigurationSource;
+    private final ClientRegistrationRepository clientRegistrationRepository;
+    private final CookieAuthorizationRequestRepository cookieAuthorizationRequestRepository;
+
+    @Value("${custom.oauth2.allowed-redirect-origins}")
+    private List<String> allowedRedirectOrigins;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -42,6 +52,10 @@ public class SecurityConfig {
             .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
 
             .oauth2Login(oauth2 -> oauth2
+                .authorizationEndpoint(auth -> auth
+                    .authorizationRequestResolver(
+                        new CustomAuthorizationRequestResolver(clientRegistrationRepository, allowedRedirectOrigins))
+                    .authorizationRequestRepository(cookieAuthorizationRequestRepository))
                 .userInfoEndpoint(userInfoEndpointConfig -> userInfoEndpointConfig
                     .userService(oAuth2LoginUserService))
                 .successHandler(oAuth2LoginSuccessHandler)

--- a/src/main/java/org/quizly/quizly/oauth/CookieAuthorizationRequestRepository.java
+++ b/src/main/java/org/quizly/quizly/oauth/CookieAuthorizationRequestRepository.java
@@ -1,0 +1,133 @@
+package org.quizly.quizly.oauth;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CookieAuthorizationRequestRepository
+    implements AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
+
+  private static final String AUTHORIZATION_REQUEST_COOKIE_NAME = "oauth2_auth_request";
+  private static final int COOKIE_EXPIRE_SECONDS = 180;
+
+  private final ObjectMapper objectMapper;
+
+  @Override
+  public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest request) {
+    return getCookie(request, AUTHORIZATION_REQUEST_COOKIE_NAME)
+        .map(cookie -> deserialize(cookie.getValue()))
+        .orElse(null);
+  }
+
+  @Override
+  public void saveAuthorizationRequest(OAuth2AuthorizationRequest authorizationRequest,
+      HttpServletRequest request, HttpServletResponse response) {
+    if (authorizationRequest == null) {
+      deleteCookie(response);
+      return;
+    }
+    addCookie(response, serialize(authorizationRequest));
+  }
+
+  @Override
+  public OAuth2AuthorizationRequest removeAuthorizationRequest(HttpServletRequest request,
+      HttpServletResponse response) {
+    OAuth2AuthorizationRequest authorizationRequest = loadAuthorizationRequest(request);
+    if (authorizationRequest != null) {
+      deleteCookie(response);
+    }
+    return authorizationRequest;
+  }
+
+  private void addCookie(HttpServletResponse response, String value) {
+    ResponseCookie cookie = ResponseCookie.from(AUTHORIZATION_REQUEST_COOKIE_NAME, value)
+        .httpOnly(true)
+        .secure(true)
+        .path("/")
+        .sameSite("None")
+        .maxAge(COOKIE_EXPIRE_SECONDS)
+        .build();
+    response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+  }
+
+  private void deleteCookie(HttpServletResponse response) {
+    ResponseCookie cookie = ResponseCookie.from(AUTHORIZATION_REQUEST_COOKIE_NAME, "")
+        .httpOnly(true)
+        .secure(true)
+        .path("/")
+        .sameSite("None")
+        .maxAge(0)
+        .build();
+    response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+  }
+
+  private Optional<Cookie> getCookie(HttpServletRequest request, String name) {
+    if (request.getCookies() == null) {
+      return Optional.empty();
+    }
+    return Arrays.stream(request.getCookies())
+        .filter(cookie -> name.equals(cookie.getName()))
+        .findFirst();
+  }
+
+  private record AuthRequestData(
+      String authorizationUri,
+      String clientId,
+      String redirectUri,
+      Set<String> scopes,
+      String state,
+      Map<String, Object> additionalParameters,
+      Map<String, Object> attributes,
+      String authorizationRequestUri
+  ) {}
+
+  private String serialize(OAuth2AuthorizationRequest request) {
+    AuthRequestData data = new AuthRequestData(
+        request.getAuthorizationUri(),
+        request.getClientId(),
+        request.getRedirectUri(),
+        request.getScopes(),
+        request.getState(),
+        request.getAdditionalParameters(),
+        request.getAttributes(),
+        request.getAuthorizationRequestUri()
+    );
+    try {
+      return objectMapper.writeValueAsString(data);
+    } catch (JsonProcessingException e) {
+      throw new IllegalStateException("OAuth2 인가 요청 직렬화 실패", e);
+    }
+  }
+
+  private OAuth2AuthorizationRequest deserialize(String value) {
+    try {
+      AuthRequestData data = objectMapper.readValue(value, AuthRequestData.class);
+      return OAuth2AuthorizationRequest.authorizationCode()
+          .authorizationUri(data.authorizationUri())
+          .clientId(data.clientId())
+          .redirectUri(data.redirectUri())
+          .scopes(data.scopes())
+          .state(data.state())
+          .additionalParameters(data.additionalParameters())
+          .attributes(data.attributes())
+          .authorizationRequestUri(data.authorizationRequestUri())
+          .build();
+    } catch (JsonProcessingException e) {
+      throw new IllegalStateException("OAuth2 인가 요청 역직렬화 실패", e);
+    }
+  }
+}

--- a/src/main/java/org/quizly/quizly/oauth/CustomAuthorizationRequestResolver.java
+++ b/src/main/java/org/quizly/quizly/oauth/CustomAuthorizationRequestResolver.java
@@ -1,0 +1,92 @@
+package org.quizly.quizly.oauth;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.net.URI;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+
+@Slf4j
+public class CustomAuthorizationRequestResolver implements OAuth2AuthorizationRequestResolver {
+
+  private static final String AUTHORIZATION_BASE_URI = "/oauth2/authorization";
+
+  private final DefaultOAuth2AuthorizationRequestResolver delegate;
+  private final List<String> allowedRedirectOrigins;
+
+  public CustomAuthorizationRequestResolver(
+      ClientRegistrationRepository clientRegistrationRepository,
+      List<String> allowedRedirectOrigins) {
+    this.delegate = new DefaultOAuth2AuthorizationRequestResolver(
+        clientRegistrationRepository, AUTHORIZATION_BASE_URI);
+    this.allowedRedirectOrigins = allowedRedirectOrigins;
+  }
+
+  @Override
+  public OAuth2AuthorizationRequest resolve(HttpServletRequest request) {
+    OAuth2AuthorizationRequest authorizationRequest = delegate.resolve(request);
+    return customize(request, authorizationRequest);
+  }
+
+  @Override
+  public OAuth2AuthorizationRequest resolve(HttpServletRequest request, String clientRegistrationId) {
+    OAuth2AuthorizationRequest authorizationRequest = delegate.resolve(request, clientRegistrationId);
+    return customize(request, authorizationRequest);
+  }
+
+  private OAuth2AuthorizationRequest customize(HttpServletRequest request, OAuth2AuthorizationRequest authorizationRequest) {
+    if (authorizationRequest == null) {
+      return null;
+    }
+
+    String origin = extractOrigin(request);
+    if (origin == null || !allowedRedirectOrigins.contains(origin)) {
+      return authorizationRequest;
+    }
+
+    String registrationId = extractRegistrationId(request);
+    if (registrationId == null) {
+      return authorizationRequest;
+    }
+
+    String customRedirectUri = origin + "/login/oauth2/code/" + registrationId;
+    log.debug("[CustomAuthorizationRequestResolver] origin 감지 - redirectUri: {}", customRedirectUri);
+
+    return OAuth2AuthorizationRequest.from(authorizationRequest)
+        .redirectUri(customRedirectUri)
+        .build();
+  }
+
+  private String extractOrigin(HttpServletRequest request) {
+    String origin = request.getHeader("Origin");
+    if (origin != null && !origin.isBlank()) {
+      return origin;
+    }
+
+    String referer = request.getHeader("Referer");
+    if (referer != null && !referer.isBlank()) {
+      try {
+        URI uri = new URI(referer);
+        int port = uri.getPort();
+        return uri.getScheme() + "://" + uri.getHost() + (port != -1 ? ":" + port : "");
+      } catch (Exception e) {
+        log.warn("[CustomAuthorizationRequestResolver] Referer 파싱 실패: {}", referer);
+      }
+    }
+
+    return null;
+  }
+
+  private String extractRegistrationId(HttpServletRequest request) {
+    String uri = request.getRequestURI();
+    String prefix = AUTHORIZATION_BASE_URI + "/";
+    int idx = uri.indexOf(prefix);
+    if (idx < 0) {
+      return null;
+    }
+    return uri.substring(idx + prefix.length());
+  }
+}

--- a/src/main/java/org/quizly/quizly/oauth/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/org/quizly/quizly/oauth/OAuth2LoginSuccessHandler.java
@@ -74,7 +74,7 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
             .httpOnly(true)
             .secure(true)
             .path("/")
-            .sameSite("Lax")
+            .sameSite("Strict")
             .maxAge(refreshTokenExpiration / 1000)
             .build();
 

--- a/src/main/java/org/quizly/quizly/oauth/controller/delete/RevokeRefreshTokenController.java
+++ b/src/main/java/org/quizly/quizly/oauth/controller/delete/RevokeRefreshTokenController.java
@@ -58,7 +58,7 @@ public class RevokeRefreshTokenController {
             .httpOnly(true)
             .secure(true)
             .path("/")
-            .sameSite("Lax")
+            .sameSite("Strict")
             .maxAge(0)
             .build();
 

--- a/src/main/java/org/quizly/quizly/oauth/controller/post/ReissueAccessTokenController.java
+++ b/src/main/java/org/quizly/quizly/oauth/controller/post/ReissueAccessTokenController.java
@@ -63,7 +63,7 @@ public class ReissueAccessTokenController {
             .httpOnly(true)
             .secure(true)
             .path("/")
-            .sameSite("Lax")
+            .sameSite("Strict")
             .maxAge((int) (refreshTokenExpiration / 1000))
             .build();
 


### PR DESCRIPTION
## 연관 이슈
- 이 PR이 해결하는 이슈: #163

## 작업 사항
- `CorsMvcConfig`에서 허용 Origin 단일 프로퍼티로 통합 관리
- Origin별 `redirect_uri` 동적 분기
    - 프론트 로컬에서도 실서버 API로 소셜 로그인을 테스트할 수 있도록 수정 (프론트 요청 사항)
    - 요청의 Origin을 기준으로 redirect_uri를 런타임에 생성하도록 변경
- 인가 요청 저장: 세션 → 쿠키 전환
    - 크로스 도메인 OAuth2 콜백 시 state 검증 가능하도록 수정
- refresh token 쿠키 SameSite 통일
    - refreshToken 쿠키의 SameSite를 Strict로 변경해 CSRF 노출 범위를 축소
    (실서버는 same-site라 Strict여도 refreshToken이 정상 전송, 로컬(cross-site)에서는 토큰 재발급이 동작하지 않음)


## 테스트 (프론트 개발 속도에 따라 선배포하여 테스트 완료)
- [X] 실서버 (quizly.co.kr → api.quizly.co.kr, same-site) 네이버/카카오 로그인 성공
- [ ] 로그인 이후 accessToken 헤더 기반 API 정상 동작

## 주의 사항 및 참고사항
- application.yml 파일 변경 사항 존재 (redirect_uri  추가)
    - [X] Actions secrets APPLICATION_YML_PROD 업데이트
    - [X] 팀 노션 application.yml 업데이트
- 프론트 대응 필요
    - `.env`의 `VITE_API_BASE_URL` 실서버 주소로 변경
    - 로컬에서 테스트 시 크롬 서드파티 쿠키 허용