### PR TITLE
feat(#168): 온보딩 완료 시 회원가입 Slack 알림 스레드에 온보딩 정보 댓글 발송

### DIFF
--- a/src/main/java/org/quizly/quizly/account/event/OnboardingCompletedEvent.java
+++ b/src/main/java/org/quizly/quizly/account/event/OnboardingCompletedEvent.java
@@ -1,0 +1,7 @@
+package org.quizly.quizly.account.event;
+
+import org.quizly.quizly.core.domain.entity.User;
+
+public record OnboardingCompletedEvent(User user) {
+
+}

--- a/src/main/java/org/quizly/quizly/account/listener/OnboardingNotificationListener.java
+++ b/src/main/java/org/quizly/quizly/account/listener/OnboardingNotificationListener.java
@@ -1,0 +1,36 @@
+package org.quizly.quizly.account.listener;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.quizly.quizly.account.event.OnboardingCompletedEvent;
+import org.quizly.quizly.account.message.OnboardingNotificationMessage;
+import org.quizly.quizly.core.domain.entity.User;
+import org.quizly.quizly.core.notification.NotificationProvider;
+import org.quizly.quizly.core.notification.NotificationThreadRepository;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Log4j2
+@Component
+@RequiredArgsConstructor
+public class OnboardingNotificationListener {
+
+    private final NotificationProvider notificationProvider;
+    private final NotificationThreadRepository notificationThreadRepository;
+
+    @Async("notificationTaskExecutor")
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handle(OnboardingCompletedEvent event) {
+        User user = event.user();
+        Long userId = user.getId();
+        try {
+            String threadTs = notificationThreadRepository.find(userId).orElse(null);
+            notificationProvider.send(new OnboardingNotificationMessage(user, threadTs));
+            notificationThreadRepository.delete(userId);
+        } catch (Exception e) {
+            log.warn("[OnboardingNotificationListener] 온보딩 완료 슬랙 알림 전송 실패. userId: {}", userId, e);
+        }
+    }
+}

--- a/src/main/java/org/quizly/quizly/account/message/OnboardingNotificationMessage.java
+++ b/src/main/java/org/quizly/quizly/account/message/OnboardingNotificationMessage.java
@@ -1,0 +1,44 @@
+package org.quizly.quizly.account.message;
+
+import org.quizly.quizly.core.domain.entity.User;
+import org.quizly.quizly.core.notification.NotificationChannel;
+import org.quizly.quizly.core.notification.NotificationMessage;
+
+public class OnboardingNotificationMessage implements NotificationMessage {
+
+    private final User user;
+    private final String threadTs;
+
+    public OnboardingNotificationMessage(User user, String threadTs) {
+        this.user = user;
+        this.threadTs = threadTs;
+    }
+
+    @Override
+    public String title() {
+        return "온보딩 완료";
+    }
+
+    @Override
+    public String body() {
+        String info = "닉네임: " + user.getNickName() + "\n"
+            + "study_goal: " + user.getStudyGoal() + "\n"
+            + "target_type: " + user.getTargetType();
+
+        if (threadTs == null) {
+            return "⚠️ 가입 알림 스레드를 찾지 못했습니다. (7일 경과 또는 가입 알림 누락)\n"
+                + info;
+        }
+        return info;
+    }
+
+    @Override
+    public NotificationChannel channel() {
+        return NotificationChannel.SIGNUP;
+    }
+
+    @Override
+    public String threadTs() {
+        return threadTs;
+    }
+}

--- a/src/main/java/org/quizly/quizly/account/service/CreateOnboardingService.java
+++ b/src/main/java/org/quizly/quizly/account/service/CreateOnboardingService.java
@@ -10,6 +10,7 @@ import lombok.Setter;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 import lombok.extern.log4j.Log4j2;
+import org.quizly.quizly.account.event.OnboardingCompletedEvent;
 import org.quizly.quizly.core.application.BaseRequest;
 import org.quizly.quizly.core.application.BaseResponse;
 import org.quizly.quizly.core.application.BaseService;
@@ -18,6 +19,7 @@ import org.quizly.quizly.core.domain.repository.UserRepository;
 import org.quizly.quizly.core.exception.DomainException;
 import org.quizly.quizly.core.exception.error.BaseErrorCode;
 import org.quizly.quizly.oauth.UserPrincipal;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -32,6 +34,7 @@ public class CreateOnboardingService
     CreateOnboardingService.CreateOnboardingResponse> {
 
     private final UserRepository userRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Override
     public CreateOnboardingResponse execute(CreateOnboardingRequest request) {
@@ -65,6 +68,8 @@ public class CreateOnboardingService
         user.setStudyGoal(request.getStudyGoal());
         user.setOnboardingCompleted(true);
         userRepository.save(user);
+
+        eventPublisher.publishEvent(new OnboardingCompletedEvent(user));
 
         return CreateOnboardingResponse.builder().build();
     }

--- a/src/main/java/org/quizly/quizly/configuration/AsyncConfig.java
+++ b/src/main/java/org/quizly/quizly/configuration/AsyncConfig.java
@@ -43,4 +43,15 @@ public class AsyncConfig {
         return executor;
     }
 
+    @Bean(name = "notificationTaskExecutor")
+    public Executor notificationTaskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(5);
+        executor.setMaxPoolSize(10);
+        executor.setQueueCapacity(50);
+        executor.setThreadNamePrefix("Notification-");
+        executor.initialize();
+        return executor;
+    }
+
 }

--- a/src/main/java/org/quizly/quizly/core/domain/repository/redis/RedisNotificationThreadRepository.java
+++ b/src/main/java/org/quizly/quizly/core/domain/repository/redis/RedisNotificationThreadRepository.java
@@ -1,0 +1,37 @@
+package org.quizly.quizly.core.domain.repository.redis;
+
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import org.quizly.quizly.core.notification.NotificationThreadRepository;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class RedisNotificationThreadRepository implements NotificationThreadRepository {
+
+    private static final String KEY_PREFIX = "slack:signup:thread:";
+    private static final long TTL_DAYS = 7;
+
+    private final StringRedisTemplate redisTemplate;
+
+    @Override
+    public void save(Long referenceId, String threadTs) {
+        redisTemplate.opsForValue().set(key(referenceId), threadTs, TTL_DAYS, TimeUnit.DAYS);
+    }
+
+    @Override
+    public Optional<String> find(Long referenceId) {
+        return Optional.ofNullable(redisTemplate.opsForValue().get(key(referenceId)));
+    }
+
+    @Override
+    public void delete(Long referenceId) {
+        redisTemplate.delete(key(referenceId));
+    }
+
+    private String key(Long referenceId) {
+        return KEY_PREFIX + referenceId;
+    }
+}

--- a/src/main/java/org/quizly/quizly/core/notification/NotificationMessage.java
+++ b/src/main/java/org/quizly/quizly/core/notification/NotificationMessage.java
@@ -8,4 +8,8 @@ public interface NotificationMessage {
     String body();
 
     NotificationChannel channel();
+
+    default String threadTs() {
+        return null;
+    }
 }

--- a/src/main/java/org/quizly/quizly/core/notification/NotificationProvider.java
+++ b/src/main/java/org/quizly/quizly/core/notification/NotificationProvider.java
@@ -1,6 +1,8 @@
 package org.quizly.quizly.core.notification;
 
+import java.util.Optional;
+
 public interface NotificationProvider {
 
-    void send(NotificationMessage message);
+    Optional<String> send(NotificationMessage message);
 }

--- a/src/main/java/org/quizly/quizly/core/notification/NotificationThreadRepository.java
+++ b/src/main/java/org/quizly/quizly/core/notification/NotificationThreadRepository.java
@@ -1,0 +1,12 @@
+package org.quizly.quizly.core.notification;
+
+import java.util.Optional;
+
+public interface NotificationThreadRepository {
+
+    void save(Long referenceId, String threadTs);
+
+    Optional<String> find(Long referenceId);
+
+    void delete(Long referenceId);
+}

--- a/src/main/java/org/quizly/quizly/external/slack/dto/Request/SlackPostMessageRequest.java
+++ b/src/main/java/org/quizly/quizly/external/slack/dto/Request/SlackPostMessageRequest.java
@@ -1,0 +1,12 @@
+package org.quizly.quizly.external.slack.dto.Request;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record SlackPostMessageRequest(
+    String channel,
+    String text,
+    @JsonProperty("thread_ts") String threadTs) {
+
+}

--- a/src/main/java/org/quizly/quizly/external/slack/dto/Response/SlackPostMessageResponse.java
+++ b/src/main/java/org/quizly/quizly/external/slack/dto/Response/SlackPostMessageResponse.java
@@ -1,0 +1,8 @@
+package org.quizly.quizly.external.slack.dto.Response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record SlackPostMessageResponse(boolean ok, String ts, String error) {
+
+}

--- a/src/main/java/org/quizly/quizly/external/slack/service/NoOpSlackNotificationService.java
+++ b/src/main/java/org/quizly/quizly/external/slack/service/NoOpSlackNotificationService.java
@@ -1,5 +1,6 @@
 package org.quizly.quizly.external.slack.service;
 
+import java.util.Optional;
 import org.quizly.quizly.core.notification.NotificationMessage;
 import org.quizly.quizly.core.notification.NotificationProvider;
 import org.springframework.context.annotation.Profile;
@@ -10,7 +11,7 @@ import org.springframework.stereotype.Service;
 public class NoOpSlackNotificationService implements NotificationProvider {
 
     @Override
-    public void send(NotificationMessage message) {
-
+    public Optional<String> send(NotificationMessage message) {
+        return Optional.empty();
     }
 }

--- a/src/main/java/org/quizly/quizly/external/slack/service/SlackNotificationService.java
+++ b/src/main/java/org/quizly/quizly/external/slack/service/SlackNotificationService.java
@@ -1,124 +1,47 @@
 package org.quizly.quizly.external.slack.service;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
-import lombok.experimental.SuperBuilder;
 import lombok.extern.slf4j.Slf4j;
-import org.quizly.quizly.core.application.BaseRequest;
-import org.quizly.quizly.core.application.BaseResponse;
-import org.quizly.quizly.core.application.BaseService;
-import org.quizly.quizly.core.exception.DomainException;
-import org.quizly.quizly.core.exception.error.BaseErrorCode;
-import org.quizly.quizly.core.notification.NotificationChannel;
 import org.quizly.quizly.core.notification.NotificationMessage;
 import org.quizly.quizly.core.notification.NotificationProvider;
-import org.quizly.quizly.external.slack.dto.Request.SlackRequest;
-import org.springframework.beans.factory.annotation.Value;
+import org.quizly.quizly.external.slack.service.sender.SlackMessageSender;
 import org.springframework.context.annotation.Profile;
 import org.springframework.core.env.Environment;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
-import org.springframework.web.client.RestClientException;
-import org.springframework.web.client.RestTemplate;
 
 @Profile({"dev", "prod"})
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class SlackNotificationService implements NotificationProvider,
-    BaseService<SlackNotificationService.NotificationRequest, SlackNotificationService.NotificationResponse> {
+public class SlackNotificationService implements NotificationProvider {
 
-    @Value("${notification.slack.batch.webhook-url}")
-    private String batchWebhookUrl;
-
-    @Value("${notification.slack.signup.webhook-url}")
-    private String signupWebhookUrl;
-
-    private final RestTemplate restTemplate;
+    private final List<SlackMessageSender> senders;
     private final Environment environment;
 
     @Override
-    public void send(NotificationMessage message) {
+    public Optional<String> send(NotificationMessage message) {
         if (message == null) {
-            return;
+            return Optional.empty();
         }
-        String text = format(message);
-        String webhookUrl = getWebhookUrl(message.channel());
-        this.execute(new NotificationRequest(text, webhookUrl));
-    }
 
-    private String getWebhookUrl(NotificationChannel channel) {
-        return switch (channel) {
-            case SIGNUP -> signupWebhookUrl;
-            case BATCH -> batchWebhookUrl;
-            default -> throw new IllegalArgumentException("지원하지 않는 알림 채널입니다: " + channel);
-        };
+        SlackMessageSender sender = senders.stream()
+            .filter(s -> s.supports(message.channel()))
+            .findFirst()
+            .orElse(null);
+
+        if (sender == null) {
+            log.warn("[SlackNotificationService] 지원하지 않는 알림 채널입니다: {}", message.channel());
+            return Optional.empty();
+        }
+
+        return sender.send(format(message), message.threadTs());
     }
 
     private String format(NotificationMessage message) {
         String[] profiles = environment.getActiveProfiles();
         String profile = profiles.length > 0 ? profiles[0].toUpperCase() : "UNKNOWN";
         return "[" + profile + "] [" + message.title() + "]\n" + message.body();
-    }
-
-    @Override
-    public NotificationResponse execute(NotificationRequest request) {
-        if (request == null || !request.isValid()) {
-            return NotificationResponse.builder().success(false).build();
-        }
-
-        try {
-            SlackRequest slackRequest = new SlackRequest(request.getMessage());
-            restTemplate.postForEntity(request.getWebhookUrl(), slackRequest, String.class);
-
-            return NotificationResponse.builder()
-                .success(true)
-                .build();
-        } catch (RestClientException e) {
-            log.error("[SlackNotificationService] 전송 실패", e);
-            return NotificationResponse.builder()
-                .success(false)
-                .errorCode(NotificationErrorCode.SEND_FAILED)
-                .build();
-        }
-    }
-
-    @Getter
-    @RequiredArgsConstructor
-    public enum NotificationErrorCode implements BaseErrorCode<DomainException> {
-        SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "알림 전송 중 오류가 발생했습니다.");
-
-        private final HttpStatus httpStatus;
-        private final String message;
-
-        @Override
-        public DomainException toException() {
-            return new DomainException(httpStatus, this);
-        }
-    }
-
-    @Getter
-    @AllArgsConstructor
-    @NoArgsConstructor
-    public static class NotificationRequest implements BaseRequest {
-
-        private String message;
-        private String webhookUrl;
-
-        @Override
-        public boolean isValid() {
-
-            return message != null && !message.isBlank()
-                && webhookUrl != null && !webhookUrl.isBlank();
-        }
-    }
-
-    @Getter
-    @SuperBuilder
-    @NoArgsConstructor
-    public static class NotificationResponse extends BaseResponse<NotificationErrorCode> {
-
     }
 }

--- a/src/main/java/org/quizly/quizly/external/slack/service/sender/SlackApiSender.java
+++ b/src/main/java/org/quizly/quizly/external/slack/service/sender/SlackApiSender.java
@@ -1,0 +1,67 @@
+package org.quizly.quizly.external.slack.service.sender;
+
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.quizly.quizly.core.notification.NotificationChannel;
+import org.quizly.quizly.external.slack.dto.Request.SlackPostMessageRequest;
+import org.quizly.quizly.external.slack.dto.Response.SlackPostMessageResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+@Profile({"dev", "prod"})
+@Slf4j
+@Component
+public class SlackApiSender implements SlackMessageSender {
+
+    private static final String POST_MESSAGE_URL = "https://slack.com/api/chat.postMessage";
+
+    private final RestTemplate restTemplate;
+    private final String botToken;
+    private final String channelId;
+
+    public SlackApiSender(
+        RestTemplate restTemplate,
+        @Value("${notification.slack.signup.bot-token}") String botToken,
+        @Value("${notification.slack.signup.channel-id}") String channelId) {
+        this.restTemplate = restTemplate;
+        this.botToken = botToken;
+        this.channelId = channelId;
+    }
+
+    @Override
+    public boolean supports(NotificationChannel channel) {
+        return channel == NotificationChannel.SIGNUP;
+    }
+
+    @Override
+    public Optional<String> send(String text, String threadTs) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.setBearerAuth(botToken);
+
+        SlackPostMessageRequest body = new SlackPostMessageRequest(channelId, text, threadTs);
+        HttpEntity<SlackPostMessageRequest> httpEntity = new HttpEntity<>(body, headers);
+
+        try {
+            SlackPostMessageResponse response =
+                restTemplate.postForObject(POST_MESSAGE_URL, httpEntity, SlackPostMessageResponse.class);
+
+            if (response == null || !response.ok()) {
+                log.error(
+                    "[SlackApiSender] 전송 실패. error: {}",
+                    response == null ? "no response" : response.error());
+                return Optional.empty();
+            }
+            return Optional.ofNullable(response.ts());
+        } catch (RestClientException e) {
+            log.error("[SlackApiSender] 전송 실패", e);
+            return Optional.empty();
+        }
+    }
+}

--- a/src/main/java/org/quizly/quizly/external/slack/service/sender/SlackMessageSender.java
+++ b/src/main/java/org/quizly/quizly/external/slack/service/sender/SlackMessageSender.java
@@ -1,0 +1,11 @@
+package org.quizly.quizly.external.slack.service.sender;
+
+import java.util.Optional;
+import org.quizly.quizly.core.notification.NotificationChannel;
+
+public interface SlackMessageSender {
+
+    boolean supports(NotificationChannel channel);
+
+    Optional<String> send(String text, String threadTs);
+}

--- a/src/main/java/org/quizly/quizly/external/slack/service/sender/SlackWebhookSender.java
+++ b/src/main/java/org/quizly/quizly/external/slack/service/sender/SlackWebhookSender.java
@@ -1,0 +1,42 @@
+package org.quizly.quizly.external.slack.service.sender;
+
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.quizly.quizly.core.notification.NotificationChannel;
+import org.quizly.quizly.external.slack.dto.Request.SlackRequest;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+@Profile({"dev", "prod"})
+@Slf4j
+@Component
+public class SlackWebhookSender implements SlackMessageSender {
+
+    private final RestTemplate restTemplate;
+    private final String batchWebhookUrl;
+
+    public SlackWebhookSender(
+        RestTemplate restTemplate,
+        @Value("${notification.slack.batch.webhook-url}") String batchWebhookUrl) {
+        this.restTemplate = restTemplate;
+        this.batchWebhookUrl = batchWebhookUrl;
+    }
+
+    @Override
+    public boolean supports(NotificationChannel channel) {
+        return channel == NotificationChannel.BATCH;
+    }
+
+    @Override
+    public Optional<String> send(String text, String threadTs) {
+        try {
+            restTemplate.postForEntity(batchWebhookUrl, new SlackRequest(text), String.class);
+        } catch (RestClientException e) {
+            log.error("[SlackWebhookSender] 전송 실패", e);
+        }
+        return Optional.empty();
+    }
+}

--- a/src/main/java/org/quizly/quizly/oauth/message/SignupNotificationMessage.java
+++ b/src/main/java/org/quizly/quizly/oauth/message/SignupNotificationMessage.java
@@ -7,9 +7,11 @@ import org.quizly.quizly.core.notification.NotificationMessage;
 public class SignupNotificationMessage implements NotificationMessage {
 
     private final User user;
+    private final long totalMemberCount;
 
-    public SignupNotificationMessage(User user) {
+    public SignupNotificationMessage(User user, long totalMemberCount) {
         this.user = user;
+        this.totalMemberCount = totalMemberCount;
     }
 
     @Override
@@ -20,6 +22,7 @@ public class SignupNotificationMessage implements NotificationMessage {
     @Override
     public String body() {
         return "새로운 유저가 가입했습니다!\n"
+            + "누적 가입자: " + totalMemberCount + "명\n"
             + "닉네임: " + user.getNickName() + "\n"
             + "가입 시각: " + user.getCreatedAt() + "\n"
             + "provider: " + user.getProvider();

--- a/src/main/java/org/quizly/quizly/oauth/service/OAuth2LoginUserService.java
+++ b/src/main/java/org/quizly/quizly/oauth/service/OAuth2LoginUserService.java
@@ -8,6 +8,7 @@ import org.quizly.quizly.core.domain.entity.User.Provider;
 import org.quizly.quizly.core.domain.entity.User.Role;
 import org.quizly.quizly.core.domain.repository.UserRepository;
 import org.quizly.quizly.core.notification.NotificationProvider;
+import org.quizly.quizly.core.notification.NotificationThreadRepository;
 import org.quizly.quizly.oauth.UserPrincipal;
 import org.quizly.quizly.oauth.dto.response.KakaoUserInfo;
 import org.quizly.quizly.oauth.dto.response.NaverUserInfo;
@@ -26,6 +27,7 @@ public class OAuth2LoginUserService extends DefaultOAuth2UserService {
 
     private final UserRepository userRepository;
     private final NotificationProvider notificationProvider;
+    private final NotificationThreadRepository notificationThreadRepository;
 
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
@@ -83,7 +85,9 @@ public class OAuth2LoginUserService extends DefaultOAuth2UserService {
         User savedUser = userRepository.save(userEntity);
 
         try {
-            notificationProvider.send(new SignupNotificationMessage(savedUser));
+            long totalMemberCount = userRepository.count();
+            notificationProvider.send(new SignupNotificationMessage(savedUser, totalMemberCount))
+                .ifPresent(threadTs -> notificationThreadRepository.save(savedUser.getId(), threadTs));
         } catch (Exception e) {
             log.warn("[OAuth2LoginUserService] 회원가입 슬랙 알림 전송 실패. userId: {}", savedUser.getId(), e);
         }


### PR DESCRIPTION
## 연관 이슈
- 이 PR이 해결하는 이슈: #168

## 작업 사항
- 회원가입, 온보딩 완료 알림을 하나의 Slack스레드로 묶어 유저별 확인 가능하도록 변경
    - 기존 방식(`Webhook`)만으로는 스레드 연결이 불가능하여, 가입 알림을 Slack Chat API로 전환
    (프로젝트에 Slack 알림 2가지 방식 존재)
- Redis로 가입~온보딩(최대 7일) 스레드 연결
    - 가입과 온보딩은 서로 다른 요청 시점이라, 두 알림을 잇는 thread_ts를 Redis에 저장
    - 7일 내 온보딩을 안 하면 자동 만료 → 이후 온보딩 시엔 최상위 메시지로 정상 발송

## 테스트
- [X] 로컬 서버 테스트 완료
    <img width="45%" alt="스크린샷 2026-07-10 오후 3 58 22" src="https://github.com/user-attachments/assets/dea90bad-dacf-44ef-a0f2-5ecee836a542" />

## 주의 사항 및 참고사항
- application.yml 파일 변경 사항 존재 (`notification:` 변경점 존재)
    - [x] Actions secrets APPLICATION_YML_PROD 업데이트 (실서버 배포 시점)
    - [x] 팀 노션 application.yml 업데이트 (prod)
    - [X] 팀 노션 application.yml 업데이트 (local)
