### PR TITLE
feat(#173): Sentry 에러 추적 도입 및 서버 리소스, 예외 처리 개선

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,4 @@ FROM openjdk:17.0.2-jdk-slim
 WORKDIR /app
 COPY build/libs/*.jar app.jar
 EXPOSE 8080
-ENTRYPOINT ["java", "-Duser.timezone=Asia/Seoul", "-jar", "app.jar"]
+ENTRYPOINT ["java", "-XX:MaxRAMPercentage=75.0", "-Duser.timezone=Asia/Seoul", "-jar", "app.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -81,6 +81,10 @@ dependencies {
 	// Actuator
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
+	// Sentry
+	implementation 'io.sentry:sentry-spring-boot-starter-jakarta:8.16.0'
+	implementation 'io.sentry:sentry-logback:8.16.0'
+
 	// mail
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'

--- a/deploy-prod.sh
+++ b/deploy-prod.sh
@@ -33,7 +33,7 @@ docker run -d --name "$TARGET_NAME" \
   --network host \
   -e SERVER_PORT=${TARGET_PORT} \
   -v "$LOG_DIR":/logs \
-  --memory="1280m" \
+  --memory="2048m" \
   "$FULL_IMAGE_NAME"
 
 echo "> Health Check (http://localhost:${TARGET_PORT}/)..."

--- a/src/main/java/org/quizly/quizly/account/service/CreateOnboardingService.java
+++ b/src/main/java/org/quizly/quizly/account/service/CreateOnboardingService.java
@@ -55,7 +55,7 @@ public class CreateOnboardingService
 
         Optional<User> userOptional = userRepository.findById(userId);
         if (userOptional.isEmpty()) {
-            log.error("[CreateOnboardingService] User not found for userId: {}", userId);
+            log.warn("[CreateOnboardingService] User not found for userId: {}", userId);
             return CreateOnboardingResponse.builder()
                 .success(false)
                 .errorCode(CreateOnboardingErrorCode.NOT_FOUND_USER)

--- a/src/main/java/org/quizly/quizly/account/service/ReadUserService.java
+++ b/src/main/java/org/quizly/quizly/account/service/ReadUserService.java
@@ -50,7 +50,7 @@ public class ReadUserService implements
 
         Optional<User> userOptional = userRepository.findById(userId);
         if (userOptional.isEmpty()) {
-            log.error("[ReadUserService] User not found for userId: {}", userId);
+            log.warn("[ReadUserService] User not found for userId: {}", userId);
             return ReadUserResponse.builder()
                 .success(false)
                 .errorCode(ReadUserErrorCode.NOT_FOUND_USER)

--- a/src/main/java/org/quizly/quizly/admin/service/AdminReplyInquiryService.java
+++ b/src/main/java/org/quizly/quizly/admin/service/AdminReplyInquiryService.java
@@ -69,7 +69,7 @@ public class AdminReplyInquiryService implements
 
             EmailService.EmailResponse emailResponse = emailService.execute(emailRequest);
             if (emailResponse == null || !emailResponse.isSuccess()) {
-                log.error("Failed to send reply notification email to: {}", user.getEmail());
+                log.warn("Failed to send reply notification email to: {}", user.getEmail());
 
                 return AdminReplyInquiryResponse.builder()
                     .success(false)

--- a/src/main/java/org/quizly/quizly/admin/service/BatchAggregateSummaryService.java
+++ b/src/main/java/org/quizly/quizly/admin/service/BatchAggregateSummaryService.java
@@ -52,7 +52,7 @@ public class BatchAggregateSummaryService implements
 
         var userOptional = userRepository.findById(userId);
         if (userOptional.isEmpty()) {
-            log.error("[BatchAggregateSummaryService] User not found for userId: {}", userId);
+            log.warn("[BatchAggregateSummaryService] User not found for userId: {}", userId);
             return BatchAggregateSummaryResponse.builder()
                 .success(false)
                 .errorCode(BatchAggregateSummaryErrorCode.NOT_FOUND_USER)

--- a/src/main/java/org/quizly/quizly/core/exception/DomainExceptionEventProcessor.java
+++ b/src/main/java/org/quizly/quizly/core/exception/DomainExceptionEventProcessor.java
@@ -1,0 +1,20 @@
+package org.quizly.quizly.core.exception;
+
+import io.sentry.EventProcessor;
+import io.sentry.Hint;
+import io.sentry.SentryEvent;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DomainExceptionEventProcessor implements EventProcessor {
+
+    @Override
+    public SentryEvent process(SentryEvent event, Hint hint) {
+        if (event.getThrowable() instanceof DomainException e) {
+            event.setFingerprints(List.of(e.getCode()));
+            event.setTag("errorCode", e.getCode());
+        }
+        return event;
+    }
+}

--- a/src/main/java/org/quizly/quizly/core/exception/SystemExceptionHandler.java
+++ b/src/main/java/org/quizly/quizly/core/exception/SystemExceptionHandler.java
@@ -3,37 +3,57 @@ package org.quizly.quizly.core.exception;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.quizly.quizly.core.presentation.ErrorResponse;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 @Slf4j
 @RestControllerAdvice
-public class SystemExceptionHandler {
+public class SystemExceptionHandler extends ResponseEntityExceptionHandler {
+
+    @ExceptionHandler(DomainException.class)
+    public ResponseEntity<ErrorResponse> handleDomainException(DomainException e) {
+        HttpStatus httpStatus = Optional.ofNullable(e.getHttpStatus())
+            .orElse(HttpStatus.INTERNAL_SERVER_ERROR);
+        if (httpStatus.is5xxServerError()) {
+            log.error("[SystemExceptionHandler] handleDomainException", e);
+        } else {
+            log.warn("[SystemExceptionHandler] 비즈니스 예외: {}", e.getMessage());
+        }
+        return ResponseEntity.status(httpStatus)
+            .body(ErrorResponse.of(e));
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<ErrorResponse> handleAccessDeniedException(AccessDeniedException e) {
+        log.warn("[SystemExceptionHandler] Access Denied: {}", e.getMessage());
+        return ResponseEntity.status(HttpStatus.FORBIDDEN)
+            .body(ErrorResponse.of(403, e));
+    }
 
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<ErrorResponse> handleException(Exception e) {
+    public ResponseEntity<ErrorResponse> handleUnexpectedException(Exception e) {
         log.error("[SystemExceptionHandler] handleException", e);
         return ResponseEntity.internalServerError()
             .body(ErrorResponse.of(500, e));
     }
 
-    @ExceptionHandler(DomainException.class)
-    public ResponseEntity<ErrorResponse> handleException(DomainException e) {
-        log.error("[SystemExceptionHandler] handleDomainException", e);
-        HttpStatus httpStatus = Optional.ofNullable(e.getHttpStatus())
-            .orElse(HttpStatus.INTERNAL_SERVER_ERROR);
-        ErrorResponse errorResponse = ErrorResponse.of(e);
-        return ResponseEntity.status(httpStatus)
-            .body(errorResponse);
-    }
-
-    @ExceptionHandler(AccessDeniedException.class)
-    public ResponseEntity<ErrorResponse> handleAccessDeniedException(AccessDeniedException e) {
-        log.warn("[SystemExceptionHandler] Access Denied", e);
-        return ResponseEntity.status(HttpStatus.FORBIDDEN)
-            .body(ErrorResponse.of(403, e));
+    @Override
+    protected ResponseEntity<Object> handleExceptionInternal(Exception ex, Object body,
+        HttpHeaders headers, HttpStatusCode statusCode, WebRequest request) {
+        if (statusCode.is5xxServerError()) {
+            log.error("[SystemExceptionHandler] 프레임워크 서버 오류", ex);
+        } else {
+            log.warn("[SystemExceptionHandler] 프레임워크 요청 오류({}): {}",
+                statusCode.value(), ex.getMessage());
+        }
+        ErrorResponse errorResponse = ErrorResponse.of(statusCode.value(), ex);
+        return new ResponseEntity<>(errorResponse, headers, statusCode);
     }
 }

--- a/src/main/java/org/quizly/quizly/external/openai/service/CreateMockExamOpenAiService.java
+++ b/src/main/java/org/quizly/quizly/external/openai/service/CreateMockExamOpenAiService.java
@@ -71,7 +71,7 @@ public class CreateMockExamOpenAiService implements
         try (Response response = createRequest(httpRequest)) {
             ResponseBody body = response.body();
             if (body == null) {
-                log.error("[CreateMockExamOpenAiService] response body is null. response code: {}",
+                log.warn("[CreateMockExamOpenAiService] response body is null. response code: {}",
                     response.code());
                 return CreateMockExamOpenAiResponse.builder()
                     .success(false)
@@ -82,7 +82,7 @@ public class CreateMockExamOpenAiService implements
             String responseBody = body.string();
 
             if (!response.isSuccessful()) {
-                log.error(
+                log.warn(
                     "[CreateMockExamOpenAiService] OpenAi API returned non-successful code: {}, body: {}",
                     response.code(), responseBody);
                 return CreateMockExamOpenAiResponse.builder()
@@ -97,7 +97,7 @@ public class CreateMockExamOpenAiService implements
                 String content = openAiResponse.extractText();
 
                 if (content == null || content.isBlank()) {
-                    log.error(
+                    log.warn(
                         "[CreateMockExamOpenAiService] Empty content in OpenAi response. Body: {}",
                         responseBody);
                     return CreateMockExamOpenAiResponse.builder()
@@ -110,7 +110,7 @@ public class CreateMockExamOpenAiService implements
                 JsonNode quizzesNode = rootNode.path("quizzes");
 
                 if (!quizzesNode.isArray()) {
-                    log.error(
+                    log.warn(
                         "[CreateMockExamOpenAiService] Failed to find 'quizzes' array in content. Original content: {}",
                         content);
                     return CreateMockExamOpenAiResponse.builder()

--- a/src/main/java/org/quizly/quizly/external/openai/service/CreateQuizOpenAiService.java
+++ b/src/main/java/org/quizly/quizly/external/openai/service/CreateQuizOpenAiService.java
@@ -73,7 +73,7 @@ public class CreateQuizOpenAiService implements
         try (Response response = createRequest(httpRequest)) {
             ResponseBody body = response.body();
             if (body == null) {
-                log.error("[CreateQuizOpenAiService] response body is null. response code: {}",
+                log.warn("[CreateQuizOpenAiService] response body is null. response code: {}",
                     response.code());
                 return CreateQuizOpenAiResponse.builder()
                     .success(false)
@@ -84,7 +84,7 @@ public class CreateQuizOpenAiService implements
             String responseBody = body.string();
 
             if (!response.isSuccessful()) {
-                log.error(
+                log.warn(
                     "[CreateQuizOpenAiService] OpenAi API returned non-successful code: {}, body: {}",
                     response.code(), responseBody);
                 return CreateQuizOpenAiResponse.builder()
@@ -99,7 +99,7 @@ public class CreateQuizOpenAiService implements
                 String content = openAiResponse.extractText();
 
                 if (content == null || content.isBlank()) {
-                    log.error(
+                    log.warn(
                         "[CreateQuizOpenAiService] Empty content in OpenAi response. Body: {}",
                         responseBody);
                     return CreateQuizOpenAiResponse.builder()
@@ -112,7 +112,7 @@ public class CreateQuizOpenAiService implements
                 JsonNode quizzesNode = rootNode.path("quizzes");
 
                 if (!quizzesNode.isArray()) {
-                    log.error(
+                    log.warn(
                         "[CreateQuizOpenAiService] Failed to find 'quizzes' array in content. Original content: {}",
                         content);
                     return CreateQuizOpenAiResponse.builder()

--- a/src/main/java/org/quizly/quizly/external/openai/service/CreateTextOpenAiService.java
+++ b/src/main/java/org/quizly/quizly/external/openai/service/CreateTextOpenAiService.java
@@ -88,7 +88,7 @@ public class CreateTextOpenAiService implements
             String responseBody = response.body().string();
 
             if (!response.isSuccessful()) {
-                log.error("[CreateTextOpenAiService] OpenAi error {} body={}", response.code(),
+                log.warn("[CreateTextOpenAiService] OpenAi error {} body={}", response.code(),
                     responseBody);
                 return CreateTextOpenAiService.CreateTextOpenAiResponse.builder()
                     .success(false)

--- a/src/main/java/org/quizly/quizly/external/openai/service/CreateTopicOpenAiService.java
+++ b/src/main/java/org/quizly/quizly/external/openai/service/CreateTopicOpenAiService.java
@@ -68,7 +68,7 @@ public class CreateTopicOpenAiService implements
         try (Response response = createRequest(httpRequest)) {
             ResponseBody body = response.body();
             if (body == null) {
-                log.error("[CreateTopicOpenAiService] response body is null. response code: {}",
+                log.warn("[CreateTopicOpenAiService] response body is null. response code: {}",
                     response.code());
                 return CreateTopicOpenAiResponse.builder()
                     .success(false)
@@ -79,7 +79,7 @@ public class CreateTopicOpenAiService implements
             String responseBody = body.string();
 
             if (!response.isSuccessful()) {
-                log.error(
+                log.warn(
                     "[CreateTopicOpenAiService] OpenAi API returned non-successful code: {}, body: {}",
                     response.code(), responseBody);
                 return CreateTopicOpenAiResponse.builder()
@@ -94,7 +94,7 @@ public class CreateTopicOpenAiService implements
                 String content = openAiResponse.extractText();
 
                 if (content == null || content.isBlank()) {
-                    log.error(
+                    log.warn(
                         "[CreateTopicOpenAiService] Empty content in OpenAi response. Body: {}",
                         responseBody);
                     return CreateTopicOpenAiResponse.builder()
@@ -107,7 +107,7 @@ public class CreateTopicOpenAiService implements
                     GeneratedTopicResponse.class);
 
                 if (generatedTopicResponse == null || generatedTopicResponse.getTopic() == null) {
-                    log.error("[CreateTopicOpenAiService] Failed to parse topic from content: {}",
+                    log.warn("[CreateTopicOpenAiService] Failed to parse topic from content: {}",
                         content);
                     return CreateTopicOpenAiResponse.builder()
                         .success(false)

--- a/src/main/java/org/quizly/quizly/external/slack/service/sender/SlackApiSender.java
+++ b/src/main/java/org/quizly/quizly/external/slack/service/sender/SlackApiSender.java
@@ -53,14 +53,14 @@ public class SlackApiSender implements SlackMessageSender {
                 restTemplate.postForObject(POST_MESSAGE_URL, httpEntity, SlackPostMessageResponse.class);
 
             if (response == null || !response.ok()) {
-                log.error(
+                log.warn(
                     "[SlackApiSender] 전송 실패. error: {}",
                     response == null ? "no response" : response.error());
                 return Optional.empty();
             }
             return Optional.ofNullable(response.ts());
         } catch (RestClientException e) {
-            log.error("[SlackApiSender] 전송 실패", e);
+            log.warn("[SlackApiSender] 전송 실패", e);
             return Optional.empty();
         }
     }

--- a/src/main/java/org/quizly/quizly/external/slack/service/sender/SlackWebhookSender.java
+++ b/src/main/java/org/quizly/quizly/external/slack/service/sender/SlackWebhookSender.java
@@ -35,7 +35,7 @@ public class SlackWebhookSender implements SlackMessageSender {
         try {
             restTemplate.postForEntity(batchWebhookUrl, new SlackRequest(text), String.class);
         } catch (RestClientException e) {
-            log.error("[SlackWebhookSender] 전송 실패", e);
+            log.warn("[SlackWebhookSender] 전송 실패", e);
         }
         return Optional.empty();
     }

--- a/src/main/java/org/quizly/quizly/faq/service/ReadFaqService.java
+++ b/src/main/java/org/quizly/quizly/faq/service/ReadFaqService.java
@@ -30,7 +30,7 @@ public class ReadFaqService implements
     @Override
     public ReadFaqResponse execute(ReadFaqRequest request) {
         if (request == null) {
-            log.error("[ReadFaqService] request is null - unexpected service logic error");
+            log.warn("[ReadFaqService] request is null - unexpected service logic error");
             return ReadFaqResponse.builder()
                 .success(false)
                 .errorCode(ReadFaqErrorCode.NOT_EXIST_REQUIRED_PARAMETER)

--- a/src/main/java/org/quizly/quizly/mock/service/CreateMemberMockExamService.java
+++ b/src/main/java/org/quizly/quizly/mock/service/CreateMemberMockExamService.java
@@ -108,7 +108,7 @@ public class CreateMemberMockExamService implements
 
         if (generatedMockExamResponseList.isEmpty()
             || generatedMockExamResponseList.size() < quizCount) {
-            log.error(
+            log.warn(
                 "[CreateMemberMockExamService] Failed to generate any mock exams from OpenAi after all async.");
             return CreateMemberMockExamResponse.builder()
                 .success(false)

--- a/src/main/java/org/quizly/quizly/mock/service/CreateMockQuizService.java
+++ b/src/main/java/org/quizly/quizly/mock/service/CreateMockQuizService.java
@@ -49,7 +49,7 @@ public class CreateMockQuizService implements
 
         String promptPath = request.getType().getPromptPath();
         if (promptPath == null) {
-            log.error("[CreateMockQuizService] Could not find a prompt path. MockExamType: {}",
+            log.warn("[CreateMockQuizService] Could not find a prompt path. MockExamType: {}",
                 request.getType());
             return CompletableFuture.completedFuture(CreateMockQuizResponse.builder()
                 .success(false)
@@ -73,7 +73,7 @@ public class CreateMockQuizService implements
                 .build());
         }
 
-        log.error("[CreateMockQuizService] Thread: {}. Failed to create mock exam from OpenAi.",
+        log.warn("[CreateMockQuizService] Thread: {}. Failed to create mock exam from OpenAi.",
             Thread.currentThread().getName());
         return CompletableFuture.completedFuture(CreateMockQuizResponse.builder()
             .success(false)

--- a/src/main/java/org/quizly/quizly/quiz/service/CreateGuestQuizzesService.java
+++ b/src/main/java/org/quizly/quizly/quiz/service/CreateGuestQuizzesService.java
@@ -56,7 +56,7 @@ public class CreateGuestQuizzesService implements
         List<String> chunkList = TextProcessingUtil.createChunkList(
             request.getPlainText(), DEFAULT_CHUNK_SIZE, DEFAULT_CHUNK_OVERLAP);
         if (chunkList.isEmpty()) {
-            log.error("[CreateGuestQuizzesService] Failed to create chunks from plainText");
+            log.warn("[CreateGuestQuizzesService] Failed to create chunks from plainText");
             return CreateGuestQuizzesResponse.builder()
                 .success(false)
                 .errorCode(CreateGuestQuizzesErrorCode.FAILED_CREATE_CHUNK)

--- a/src/main/java/org/quizly/quizly/quiz/service/CreateMemberQuizzesService.java
+++ b/src/main/java/org/quizly/quizly/quiz/service/CreateMemberQuizzesService.java
@@ -88,7 +88,7 @@ public class CreateMemberQuizzesService implements
                 .build());
 
         if (createTopicResponse == null || !createTopicResponse.isSuccess()) {
-            log.error("[CreateMemberQuizzesService] Failed to create topic. Response: {}",
+            log.warn("[CreateMemberQuizzesService] Failed to create topic. Response: {}",
                 createTopicResponse);
             return CreateMemberQuizzesResponse.builder()
                 .success(false)
@@ -99,7 +99,7 @@ public class CreateMemberQuizzesService implements
         List<String> chunkList = TextProcessingUtil.createChunkList(
             request.getPlainText(), DEFAULT_CHUNK_SIZE, DEFAULT_CHUNK_OVERLAP);
         if (chunkList.isEmpty()) {
-            log.error("[CreateMemberQuizzesService] Failed to create chunks from plainText");
+            log.warn("[CreateMemberQuizzesService] Failed to create chunks from plainText");
             return CreateMemberQuizzesResponse.builder()
                 .success(false)
                 .errorCode(CreateMemberQuizzesErrorCode.FAILED_CREATE_CHUNK)

--- a/src/main/java/org/quizly/quizly/quiz/service/CreateQuizService.java
+++ b/src/main/java/org/quizly/quizly/quiz/service/CreateQuizService.java
@@ -47,7 +47,7 @@ public class CreateQuizService implements BaseAsyncService<CreateQuizRequest, Cr
         }
         String promptPath = request.getType().getPromptPath();
         if (promptPath == null) {
-            log.error("[CreateQuizService] Could not find a prompt path. QuizType: {}",
+            log.warn("[CreateQuizService] Could not find a prompt path. QuizType: {}",
                 request.getType());
             return CompletableFuture.completedFuture(CreateQuizResponse.builder()
                 .success(false)
@@ -71,7 +71,7 @@ public class CreateQuizService implements BaseAsyncService<CreateQuizRequest, Cr
                 .build());
         }
 
-        log.error("[CreateQuizService] Thread: {}. Failed to create quiz from OpenAi.",
+        log.warn("[CreateQuizService] Thread: {}. Failed to create quiz from OpenAi.",
             Thread.currentThread().getName());
         return CompletableFuture.completedFuture(CreateQuizResponse.builder()
             .success(false)

--- a/src/main/java/org/quizly/quizly/quiz/service/CreateTopicService.java
+++ b/src/main/java/org/quizly/quizly/quiz/service/CreateTopicService.java
@@ -48,7 +48,7 @@ public class CreateTopicService implements BaseService<CreateTopicRequest, Creat
         );
 
         if (openAiResponse == null || !openAiResponse.isSuccess()) {
-            log.error("[CreateTopicService] Failed to create topic from OpenAi. Response: {}",
+            log.warn("[CreateTopicService] Failed to create topic from OpenAi. Response: {}",
                 openAiResponse);
             return CreateTopicResponse.builder()
                 .success(false)
@@ -58,7 +58,7 @@ public class CreateTopicService implements BaseService<CreateTopicRequest, Creat
 
         String topic = openAiResponse.getTopic();
         if (topic == null || topic.isBlank()) {
-            log.error("[CreateTopicService] Topic is empty from OpenAi response");
+            log.warn("[CreateTopicService] Topic is empty from OpenAi response");
             return CreateTopicResponse.builder()
                 .success(false)
                 .errorCode(CreateTopicErrorCode.EMPTY_TOPIC)

--- a/src/main/java/org/quizly/quizly/quiz/service/GradeMemberQuizzesService.java
+++ b/src/main/java/org/quizly/quizly/quiz/service/GradeMemberQuizzesService.java
@@ -78,7 +78,7 @@ public class GradeMemberQuizzesService implements
         Quiz quiz = optionalQuiz.get();
 
         if (quiz.getUser() == null || !quiz.getUser().equals(user)) {
-            log.error("[GradeMemberQuizzesService] Cannot solve other quiz userId: {}, quizId: {} ",
+            log.warn("[GradeMemberQuizzesService] Cannot solve other quiz userId: {}, quizId: {} ",
                 user.getId(), quiz.getId());
             return GradeMemberQuizzesResponse.builder()
                 .success(false)
@@ -103,7 +103,7 @@ public class GradeMemberQuizzesService implements
             .findFirstByUserAndQuizOrderByCreatedAtDesc(user, quiz);
 
         if (existingHistory.isEmpty()) {
-            log.error("[GradeMemberQuizzesService] Draft not found: userId={}, quizId={}",
+            log.warn("[GradeMemberQuizzesService] Draft not found: userId={}, quizId={}",
                 user.getId(), quiz.getId());
             return GradeMemberQuizzesResponse.builder()
                 .success(false)

--- a/src/main/java/org/quizly/quizly/quiz/service/GradeMemberWrongQuizzesService.java
+++ b/src/main/java/org/quizly/quizly/quiz/service/GradeMemberWrongQuizzesService.java
@@ -78,7 +78,7 @@ public class GradeMemberWrongQuizzesService implements
         Quiz quiz = optionalQuiz.get();
 
         if (quiz.getUser() == null || !quiz.getUser().equals(user)) {
-            log.error(
+            log.warn(
                 "[GradeMemberWrongQuizzesService] Cannot solve other quiz userId: {}, quizId: {} ",
                 user.getId(), quiz.getId());
             return GradeMemberWrongQuizzesResponse.builder()


### PR DESCRIPTION
## 연관 이슈
- 이 PR이 해결하는 이슈: #173

## 작업 사항
- `infra(#NONE): 실서버 컨테이너, JVM 메모리 상향`
    - 해당 이슈 작업 중 발견한 사항으로 백엔드 서버의 메모리 여유분을 확인해서 앱 컨테이너 메모리 상한 `1280m` → `2048m` 상향
- `feat(#173): Sentry 도입 및 예외 처리 계층 개선`
    - Sentry는 백엔드 서버 부담을 줄이기 위해 자체 호스팅 대신 웹 버전으로 연동([Sentry](https://quizlystudy.sentry.io/issues/?project=4511736756109312))
    - 기존에는 프레임워크 요청 오류(깨진 JSON·잘못된 메서드·파일 크기 초과 등)가 500으로 잘못 분류돼 불필요한 Sentry 알림이 발생
        -> `ResponseEntityExceptionHandler` 도입으로 4xx 응답 + 알림 제외 처리 ([참고 노션](https://chanyoung-kwon.notion.site/Swagger-ResponseEntityExceptionHandler-265e5ea23d6b80c3bebef6396fde155d?source=copy_link) (3장))

## 테스트
- [X] 로컬 서버 테스트 완료
    <img width=50% alt="스크린샷 2026-07-16 오전 11 07 27" src="https://github.com/user-attachments/assets/1984d129-71ed-4ded-8cb6-6d1c422580d4" />


## 주의 사항 및 참고사항
- application.yml 파일 변경 사항 존재 (`sentry:` 추가)
    - [x] Actions secrets APPLICATION_YML_PROD 업데이트 (실서버 배포 시점)
    - [x] 팀 노션 application.yml 업데이트 (prod)
    - [x] 팀 노션 application.yml 업데이트 (local)
---
## 추가 진행 사항 (참고 기술 블로그 - [kakaopay](https://tech.kakaopay.com/post/frontend-sentry-monitoring/), [woowahan](https://techblog.woowahan.com/21604/))
>  회의 중 @yura0302 공유해주신 글에서 발견한 이슈 사항으로 백엔드 측 반영 완료

- `feat(#173): Sentry 도입 및 예외 처리 계층 개선`
    - `DomainException`은 예외 타입이 하나라 기본 그룹핑(스택트레이스)으로는 던진 위치별로 같은 에러가 이슈로 분열되어 `errorCode`를 `fingerprint`로 지정해 한 이슈로 병합
        <img width=80% alt="스크린샷 2026-07-21 오후 3 25 00" src="https://github.com/user-attachments/assets/6796447c-a4f0-434e-8102-e5671bc0dc38" />
- `refactor(#173): 서비스 계층 중복·오분류 로그 레벨 정리로 Sentry 알림 중복 제거` (총 34곳 에러 정리)
    - 실패 후 `DomainException`으로 재처리되는 service `log.error`를 `warn`으로 낮춤
        → 핸들러가 유일한 Sentry 소스가 되어 5xx 이벤트 중복 제거
  - 4xx 비즈니스(403/404),비핵심 알림(Slack) 로그도 `warn`으로 조정 (정상 상황 오알람 제거)
  - 근본원인 예외(`e`) 포함 로그·비동기 종단 로그는 `error` 유지

- [참고 노션](https://chanyoung-kwon.notion.site/Sentry-3a4e5ea23d6b809eb3eec0a08a2c5a98?source=copy_link)

