### PR TITLE
feat(#175): 로그 인프라 구축 (Loki/Promtail/Grafana) 및 traceId 추적 도입

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,12 @@ $RECYCLE.BIN/
 docker/mysql/db
 !docker/sample.env
 docker/.DS_Store
+docker/loki/data
+docker/grafana/data
+docker/promtail/positions
+
+# App logs (local)
+/logs
 
 # Environment variables
 .env

--- a/build.gradle
+++ b/build.gradle
@@ -89,6 +89,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 
+	// Logging (Loki/Grafana)
+	implementation 'net.logstash.logback:logstash-logback-encoder:7.4'
+
 }
 
 tasks.named('test') {

--- a/deploy-prod.sh
+++ b/deploy-prod.sh
@@ -5,8 +5,8 @@ IMAGE_PATH=$1
 IMAGE_TAG=$2
 FULL_IMAGE_NAME="${IMAGE_PATH}:${IMAGE_TAG}"
 
-LOG_DIR="/var/log/quizly"
-mkdir -p "$LOG_DIR"
+HOST_LOG_DIR="/var/log/quizly"
+mkdir -p "$HOST_LOG_DIR"
 
 echo "> 배포 시작: $FULL_IMAGE_NAME"
 
@@ -32,7 +32,8 @@ docker rm -f "$TARGET_NAME" 2>/dev/null || true
 docker run -d --name "$TARGET_NAME" \
   --network host \
   -e SERVER_PORT=${TARGET_PORT} \
-  -v "$LOG_DIR":/logs \
+  -e LOG_DIR=/logs \
+  -v "$HOST_LOG_DIR":/logs \
   --memory="2048m" \
   "$FULL_IMAGE_NAME"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,5 @@
 version: '3.8'
+name: quizly
 
 services:
 
@@ -25,3 +26,44 @@ services:
     ports:
       - "127.0.0.1:6379:6379"
     command: redis-server --maxmemory 128mb --maxmemory-policy allkeys-lru --requirepass ${REDIS_PASSWORD}
+
+  loki:
+    container_name: quizly_loki
+    image: grafana/loki:3.1.1
+    user: "10001:10001"
+    ports:
+      - "127.0.0.1:3100:3100"
+    volumes:
+      - ./docker/loki/config/loki-config.yaml:/etc/loki/local-config.yaml:ro
+      - ./docker/loki/data:/loki
+    command: -config.file=/etc/loki/local-config.yaml
+    restart: unless-stopped
+
+  promtail:
+    container_name: quizly_promtail
+    image: grafana/promtail:3.1.1
+    user: "10001:10001"
+    volumes:
+      - ./docker/promtail/promtail-config.yaml:/etc/promtail/config.yaml:ro
+      - ${QUIZLY_LOG_DIR:-/var/log/quizly}:/var/log/quizly:ro
+      - ./docker/promtail/positions:/tmp/positions
+    command: -config.file=/etc/promtail/config.yaml
+    depends_on:
+      - loki
+    restart: unless-stopped
+
+  grafana:
+    container_name: quizly_grafana
+    image: grafana/grafana:11.1.0
+    ports:
+      - "127.0.0.1:3001:3000"
+    environment:
+      GF_SECURITY_ADMIN_USER: ${GRAFANA_ADMIN_USER:-admin}
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD}
+      GF_USERS_ALLOW_SIGN_UP: "false"
+    volumes:
+      - ./docker/grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./docker/grafana/data:/var/lib/grafana
+    depends_on:
+      - loki
+    restart: unless-stopped

--- a/docker/grafana/provisioning/dashboards/dashboards.yaml
+++ b/docker/grafana/provisioning/dashboards/dashboards.yaml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+providers:
+  - name: Quizly
+    orgId: 1
+    folder: Quizly
+    type: file
+    disableDeletion: false
+    editable: true
+    options:
+      path: /etc/grafana/provisioning/dashboards/json

--- a/docker/grafana/provisioning/dashboards/json/quizly-backend-logs.json
+++ b/docker/grafana/provisioning/dashboards/json/quizly-backend-logs.json
@@ -1,0 +1,80 @@
+{
+  "title": "Quizly Backend Logs",
+  "uid": "quizly-backend-logs",
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "time": { "from": "now-6h", "to": "now" },
+  "refresh": "30s",
+  "panels": [
+    {
+      "id": 1,
+      "title": "Log volume by level",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 0 },
+      "datasource": { "type": "loki", "uid": "Loki" },
+      "targets": [
+        {
+          "expr": "sum by (level) (count_over_time({service=\"quizly-backend\"}[$__interval]))",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "{level=\"ERROR\"}" },
+            "properties": [
+              { "id": "color", "value": { "mode": "fixed", "fixedColor": "red" } }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "{level=\"WARN\"}" },
+            "properties": [
+              { "id": "color", "value": { "mode": "fixed", "fixedColor": "orange" } }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "{level=\"INFO\"}" },
+            "properties": [
+              { "id": "color", "value": { "mode": "fixed", "fixedColor": "green" } }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "{level=\"DEBUG\"}" },
+            "properties": [
+              { "id": "color", "value": { "mode": "fixed", "fixedColor": "blue" } }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "id": 2,
+      "title": "Error logs",
+      "type": "logs",
+      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 8 },
+      "datasource": { "type": "loki", "uid": "Loki" },
+      "targets": [
+        {
+          "expr": "{service=\"quizly-backend\", level=\"ERROR\"}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "All logs",
+      "type": "logs",
+      "gridPos": { "h": 12, "w": 24, "x": 0, "y": 18 },
+      "datasource": { "type": "loki", "uid": "Loki" },
+      "targets": [
+        {
+          "expr": "{service=\"quizly-backend\"}",
+          "refId": "A"
+        }
+      ]
+    }
+  ]
+}

--- a/docker/grafana/provisioning/datasources/loki.yaml
+++ b/docker/grafana/provisioning/datasources/loki.yaml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+datasources:
+  - name: Loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
+    isDefault: true
+    editable: false

--- a/docker/loki/config/loki-config.yaml
+++ b/docker/loki/config/loki-config.yaml
@@ -1,0 +1,37 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  grpc_listen_port: 9096
+
+common:
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: 2024-01-01
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+limits_config:
+  retention_period: 720h
+  reject_old_samples: true
+  reject_old_samples_max_age: 168h
+  max_query_series: 5000
+
+compactor:
+  working_directory: /loki/compactor
+  retention_enabled: true
+  delete_request_store: filesystem

--- a/docker/promtail/promtail-config.yaml
+++ b/docker/promtail/promtail-config.yaml
@@ -1,0 +1,26 @@
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+
+positions:
+  filename: /tmp/positions/positions.yaml
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+
+scrape_configs:
+  - job_name: quizly-backend
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: quizly-backend
+          service: quizly-backend
+          __path__: /var/log/quizly/*.log
+    pipeline_stages:
+      - json:
+          expressions:
+            level: level
+            logger: logger_name
+      - labels:
+          level:

--- a/src/main/java/org/quizly/quizly/configuration/LoggingConfig.java
+++ b/src/main/java/org/quizly/quizly/configuration/LoggingConfig.java
@@ -1,0 +1,23 @@
+package org.quizly.quizly.configuration;
+
+import lombok.RequiredArgsConstructor;
+import org.quizly.quizly.core.logging.TraceIdFilter;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+
+@Configuration
+@RequiredArgsConstructor
+public class LoggingConfig {
+
+    private final TraceIdFilter traceIdFilter;
+
+    @Bean
+    public FilterRegistrationBean<TraceIdFilter> traceIdFilterRegistration() {
+        FilterRegistrationBean<TraceIdFilter> registration = new FilterRegistrationBean<>(traceIdFilter);
+        registration.addUrlPatterns("/*");
+        registration.setOrder(Ordered.HIGHEST_PRECEDENCE);
+        return registration;
+    }
+}

--- a/src/main/java/org/quizly/quizly/core/logging/TraceIdFilter.java
+++ b/src/main/java/org/quizly/quizly/core/logging/TraceIdFilter.java
@@ -1,0 +1,43 @@
+package org.quizly.quizly.core.logging;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.UUID;
+import java.util.regex.Pattern;
+import org.slf4j.MDC;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+public class TraceIdFilter extends OncePerRequestFilter {
+
+    private static final String TRACE_ID_HEADER = "X-Request-Id";
+    private static final String TRACE_ID_MDC_KEY = "traceId";
+
+    private static final Pattern UUID_PATTERN =
+        Pattern.compile(
+            "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$");
+
+    @Override
+    protected void doFilterInternal(
+        HttpServletRequest request,
+        HttpServletResponse response,
+        FilterChain filterChain) throws ServletException, IOException {
+
+        String traceId = request.getHeader(TRACE_ID_HEADER);
+        if (traceId == null || !UUID_PATTERN.matcher(traceId).matches()) {
+            traceId = UUID.randomUUID().toString();
+        }
+
+        try {
+            MDC.put(TRACE_ID_MDC_KEY, traceId);
+            response.setHeader(TRACE_ID_HEADER, traceId);
+            filterChain.doFilter(request, response);
+        } finally {
+            MDC.remove(TRACE_ID_MDC_KEY);
+        }
+    }
+}

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+
+    <springProperty scope="context" name="serverPort" source="server.port" defaultValue="8080"/>
+    <springProperty scope="context" name="logDir" source="log.dir" defaultValue="./logs"/>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%clr(%d{${LOG_DATEFORMAT_PATTERN:-yyyy-MM-dd HH:mm:ss.SSS}}){faint} %clr(${LOG_LEVEL_PATTERN:-%5p}) %clr([%X{traceId}]){magenta} %clr(${PID:- }){magenta} %clr(---){faint} %clr([%15.15t]){faint} %clr(${LOG_CORRELATION_PATTERN:-}%-40.40logger{39}){cyan} %clr(:){faint} %m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${logDir}/quizly-${serverPort}.log</file>
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <customFields>{"service":"quizly-backend"}</customFields>
+        </encoder>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${logDir}/quizly-${serverPort}.%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
+            <maxFileSize>100MB</maxFileSize>
+            <maxHistory>14</maxHistory>
+            <totalSizeCap>2GB</totalSizeCap>
+        </rollingPolicy>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="FILE"/>
+    </root>
+
+</configuration>


### PR DESCRIPTION
## 연관 이슈
- 이 PR이 해결하는 이슈: #175

## 작업 사항
- traceId 추적 도입
- 수집·시각화 파이프라인 구축 (로그 파일 → Promtail → Loki → Grafana)

## 테스트
- [x] 로컬 서버 테스트 완료
    <img width=80% alt="스크린샷 2026-07-27 오전 11 25 29" src="https://github.com/user-attachments/assets/d8e9c4d5-34b6-430f-b013-f6c27228ec64" />

## 주의 사항 및 참고사항
- [X] 접속 방법 정리 (`노션 > 내부 공유 페이지 > 계정`)
- [X]  실서버 배포 시 docker compose 실행 필요 (loki / promtail / grafana)