### PR TITLE
feat(#176): 메트릭 모니터링 인프라 구축 (Prometheus + Grafana)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ docker/.DS_Store
 docker/loki/data
 docker/grafana/data
 docker/promtail/positions
+docker/prometheus/data
 
 # App logs (local)
 /logs

--- a/build.gradle
+++ b/build.gradle
@@ -80,6 +80,7 @@ dependencies {
 
 	// Actuator
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
 
 	// Sentry
 	implementation 'io.sentry:sentry-spring-boot-starter-jakarta:8.16.0'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,6 +52,22 @@ services:
       - loki
     restart: unless-stopped
 
+  prometheus:
+    container_name: quizly_prometheus
+    image: prom/prometheus:v2.53.0
+    user: "65534:65534"
+    ports:
+      - "127.0.0.1:9090:9090"
+    volumes:
+      - ./docker/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./docker/prometheus/data:/prometheus
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --storage.tsdb.retention.time=30d
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    restart: unless-stopped
+
   grafana:
     container_name: quizly_grafana
     image: grafana/grafana:11.1.0
@@ -66,4 +82,5 @@ services:
       - ./docker/grafana/data:/var/lib/grafana
     depends_on:
       - loki
+      - prometheus
     restart: unless-stopped

--- a/docker/grafana/provisioning/dashboards/json/quizly-backend-metrics.json
+++ b/docker/grafana/provisioning/dashboards/json/quizly-backend-metrics.json
@@ -1,0 +1,133 @@
+{
+  "title": "Quizly Backend Metrics",
+  "uid": "quizly-backend-metrics",
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "time": { "from": "now-1h", "to": "now" },
+  "refresh": "30s",
+  "panels": [
+    {
+      "id": 1,
+      "title": "JVM Heap Used vs Max",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "Prometheus" },
+      "fieldConfig": { "defaults": { "unit": "bytes" }, "overrides": [] },
+      "targets": [
+        {
+          "expr": "sum by (instance) (jvm_memory_used_bytes{application=\"quizly-backend\", area=\"heap\"})",
+          "legendFormat": "used - {{instance}}",
+          "refId": "A"
+        },
+        {
+          "expr": "sum by (instance) (jvm_memory_max_bytes{application=\"quizly-backend\", area=\"heap\"})",
+          "legendFormat": "max - {{instance}}",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "Process CPU Usage",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "Prometheus" },
+      "fieldConfig": { "defaults": { "unit": "percentunit" }, "overrides": [] },
+      "targets": [
+        {
+          "expr": "process_cpu_usage{application=\"quizly-backend\"}",
+          "legendFormat": "process cpu - {{instance}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "Live JVM Threads",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "Prometheus" },
+      "targets": [
+        {
+          "expr": "jvm_threads_live_threads{application=\"quizly-backend\"}",
+          "legendFormat": "live - {{instance}}",
+          "refId": "A"
+        },
+        {
+          "expr": "jvm_threads_daemon_threads{application=\"quizly-backend\"}",
+          "legendFormat": "daemon - {{instance}}",
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "GC Pause Time",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "Prometheus" },
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "targets": [
+        {
+          "expr": "rate(jvm_gc_pause_seconds_sum{application=\"quizly-backend\"}[$__rate_interval])",
+          "legendFormat": "{{action}} - {{instance}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "title": "HTTP Request Rate by Status",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
+      "datasource": { "type": "prometheus", "uid": "Prometheus" },
+      "fieldConfig": { "defaults": { "unit": "reqps" }, "overrides": [] },
+      "targets": [
+        {
+          "expr": "sum by (status, instance) (rate(http_server_requests_seconds_count{application=\"quizly-backend\"}[$__rate_interval]))",
+          "legendFormat": "{{status}} - {{instance}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "title": "HTTP Average Latency",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
+      "datasource": { "type": "prometheus", "uid": "Prometheus" },
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "targets": [
+        {
+          "expr": "sum by (instance) (rate(http_server_requests_seconds_sum{application=\"quizly-backend\"}[$__rate_interval])) / sum by (instance) (rate(http_server_requests_seconds_count{application=\"quizly-backend\"}[$__rate_interval]))",
+          "legendFormat": "avg latency - {{instance}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "title": "HikariCP Connections",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 24 },
+      "datasource": { "type": "prometheus", "uid": "Prometheus" },
+      "targets": [
+        {
+          "expr": "hikaricp_connections_active{application=\"quizly-backend\"}",
+          "legendFormat": "active - {{instance}}",
+          "refId": "A"
+        },
+        {
+          "expr": "hikaricp_connections_idle{application=\"quizly-backend\"}",
+          "legendFormat": "idle - {{instance}}",
+          "refId": "B"
+        },
+        {
+          "expr": "hikaricp_connections_pending{application=\"quizly-backend\"}",
+          "legendFormat": "pending - {{instance}}",
+          "refId": "C"
+        }
+      ]
+    }
+  ]
+}

--- a/docker/grafana/provisioning/datasources/prometheus.yaml
+++ b/docker/grafana/provisioning/datasources/prometheus.yaml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: false
+    editable: false

--- a/docker/prometheus/prometheus.yml
+++ b/docker/prometheus/prometheus.yml
@@ -1,0 +1,11 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: quizly-backend
+    metrics_path: /actuator/prometheus
+    static_configs:
+      - targets: ["host.docker.internal:8080", "host.docker.internal:8081"]
+        labels:
+          service: quizly-backend

--- a/src/main/java/org/quizly/quizly/configuration/SecurityConfig.java
+++ b/src/main/java/org/quizly/quizly/configuration/SecurityConfig.java
@@ -78,7 +78,8 @@ public class SecurityConfig {
                     "/auth/reissue",
                     "/quizzes/guest/**",
                     "/quizzes/{quizId}/answer/guest",
-                    "/actuator/health"
+                    "/actuator/health",
+                    "/actuator/prometheus"
                 ).permitAll()
                 .dispatcherTypeMatchers(DispatcherType.ASYNC).permitAll()
                 .anyRequest().authenticated());


### PR DESCRIPTION
## 연관 이슈
- 이 PR이 해결하는 이슈: #176

## 작업 사항
- 메트릭 모니터링 파이프라인 구축 (`Actuator → Prometheus → Grafana`)
- 블루/그린 배포 대응

## 테스트
- [x] 로컬 서버 테스트 완료
    <img width=80% alt="스크린샷 2026-07-29 오후 11 05 23" src="https://github.com/user-attachments/assets/a2e6216c-ed1b-4bbd-a7cf-c258aaa1a907" />

## 주의 사항 및 참고사항
- [x] 실서버 배포 시 docker compose 실행 필요 (`prometheus` / `grafana`) (docker compose 실행 과정 노션 내부 자료에 정리)
- [ ] /actuator/prometheus 외부 노출 차단 필요 (서버 nginx에서 `location = /actuator/prometheus { deny all; }`)
- [x] application.yml 파일 변경 사항 존재 (management: 수정)
    - [x] Actions secrets APPLICATION_YML_PROD 업데이트 (실서버 배포 시점)
    - [x]  팀 노션 application.yml 업데이트 (prod)
    - [X]  팀 노션 application.yml 업데이트 (local)
