### PR TITLE
refactor(#180): 소셜 로그인 시 불필요한 User 중복 조회 쿼리 제거

### DIFF
--- a/src/main/java/org/quizly/quizly/oauth/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/org/quizly/quizly/oauth/OAuth2LoginSuccessHandler.java
@@ -11,9 +11,7 @@ import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.quizly.quizly.core.domain.entity.RefreshToken;
-import org.quizly.quizly.core.domain.entity.User;
 import org.quizly.quizly.core.domain.repository.RefreshTokenRepository;
-import org.quizly.quizly.core.domain.repository.UserRepository;
 import org.quizly.quizly.jwt.JwtProvider;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
@@ -31,7 +29,6 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
 
     private final JwtProvider jwtProvider;
     private final RefreshTokenRepository refreshTokenRepository;
-    private final UserRepository userRepository;
     private final ObjectMapper objectMapper;
 
     @Value("${jwt.refresh-token-expiration}")
@@ -49,9 +46,6 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
 
         Long userId = customUserDetails.getUserId();
 
-        User user = userRepository.findById(userId)
-            .orElseThrow(() -> new IllegalStateException("User not found"));
-
         String role = authentication.getAuthorities().stream()
             .findFirst()
             .map(GrantedAuthority::getAuthority)
@@ -60,8 +54,7 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
         String accessToken = jwtProvider.generateAccessToken(userId, role);
         String refreshToken = jwtProvider.generateRefreshToken(userId);
 
-        log.info("[OAuth2LoginSuccessHandler] Login successful - userId: {}, provider: {}",
-            user.getId(), user.getProvider());
+        log.info("[OAuth2LoginSuccessHandler] Login successful - userId: {}", userId);
 
         Optional<RefreshToken> refreshTokenOptional = refreshTokenRepository.findByUserId(userId);
         if (refreshTokenOptional.isPresent()) {

--- a/src/main/java/org/quizly/quizly/oauth/service/OAuth2LoginUserService.java
+++ b/src/main/java/org/quizly/quizly/oauth/service/OAuth2LoginUserService.java
@@ -1,19 +1,15 @@
 package org.quizly.quizly.oauth.service;
 
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.quizly.quizly.core.domain.entity.User;
-import org.quizly.quizly.core.domain.entity.User.Provider;
-import org.quizly.quizly.core.domain.entity.User.Role;
-import org.quizly.quizly.core.domain.repository.UserRepository;
-import org.quizly.quizly.core.notification.NotificationProvider;
-import org.quizly.quizly.core.notification.NotificationThreadRepository;
+import org.quizly.quizly.core.exception.error.GlobalErrorCode;
 import org.quizly.quizly.oauth.UserPrincipal;
 import org.quizly.quizly.oauth.dto.response.KakaoUserInfo;
 import org.quizly.quizly.oauth.dto.response.NaverUserInfo;
 import org.quizly.quizly.oauth.dto.response.OAuth2UserInfo;
-import org.quizly.quizly.oauth.message.SignupNotificationMessage;
+import org.quizly.quizly.oauth.service.RegisterOAuthUserService.RegisterOAuthUserRequest;
+import org.quizly.quizly.oauth.service.RegisterOAuthUserService.RegisterOAuthUserResponse;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
@@ -25,9 +21,7 @@ import org.springframework.stereotype.Service;
 @Slf4j
 public class OAuth2LoginUserService extends DefaultOAuth2UserService {
 
-    private final UserRepository userRepository;
-    private final NotificationProvider notificationProvider;
-    private final NotificationThreadRepository notificationThreadRepository;
+    private final RegisterOAuthUserService registerOAuthUserService;
 
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
@@ -41,7 +35,16 @@ public class OAuth2LoginUserService extends DefaultOAuth2UserService {
             return null;
         }
 
-        User user = processUser(oAuth2UserInfo);
+        RegisterOAuthUserResponse response = registerOAuthUserService.execute(
+            RegisterOAuthUserRequest.builder().oAuth2UserInfo(oAuth2UserInfo).build());
+
+        if (!response.isSuccess()) {
+            throw response.getErrorCode() != null
+                ? response.getErrorCode().toException()
+                : GlobalErrorCode.INTERNAL_ERROR.toException();
+        }
+
+        User user = response.getUser();
 
         return new UserPrincipal(user.getId(), user.getRole());
     }
@@ -55,49 +58,5 @@ public class OAuth2LoginUserService extends DefaultOAuth2UserService {
             default:
                 return null;
         }
-    }
-
-    private User processUser(OAuth2UserInfo oAuth2UserInfo) {
-        Optional<User> existDataOptional = userRepository.findByProviderId(
-            oAuth2UserInfo.getProviderId());
-
-        return existDataOptional.map(user -> updateUser(user, oAuth2UserInfo))
-            .orElseGet(() -> createUser(oAuth2UserInfo));
-
-    }
-
-    private User createUser(OAuth2UserInfo oAuth2UserInfo) {
-        User userEntity = new User();
-
-        try {
-            Provider providerEnum = Provider.valueOf(oAuth2UserInfo.getProvider().toUpperCase());
-            userEntity.setProvider(providerEnum);
-        } catch (IllegalArgumentException e) {
-            throw new IllegalArgumentException(
-                "지원하지 않는 소셜 로그인 Provider입니다: " + oAuth2UserInfo.getProvider());
-        }
-
-        userEntity.setProviderId(oAuth2UserInfo.getProviderId());
-        userEntity.setEmail(oAuth2UserInfo.getEmail());
-        userEntity.setName(oAuth2UserInfo.getNickname());
-        userEntity.setNickName(oAuth2UserInfo.getNickname());
-        userEntity.setRole(Role.USER);
-        User savedUser = userRepository.save(userEntity);
-
-        try {
-            long totalMemberCount = userRepository.count();
-            notificationProvider.send(new SignupNotificationMessage(savedUser, totalMemberCount))
-                .ifPresent(threadTs -> notificationThreadRepository.save(savedUser.getId(), threadTs));
-        } catch (Exception e) {
-            log.warn("[OAuth2LoginUserService] 회원가입 슬랙 알림 전송 실패. userId: {}", savedUser.getId(), e);
-        }
-        return savedUser;
-    }
-
-    private User updateUser(User user, OAuth2UserInfo oAuth2UserInfo) {
-        user.setEmail(oAuth2UserInfo.getEmail());
-        user.setName(oAuth2UserInfo.getNickname());
-        userRepository.save(user);
-        return user;
     }
 }

--- a/src/main/java/org/quizly/quizly/oauth/service/RegisterOAuthUserService.java
+++ b/src/main/java/org/quizly/quizly/oauth/service/RegisterOAuthUserService.java
@@ -1,0 +1,149 @@
+package org.quizly.quizly.oauth.service;
+
+import java.util.Objects;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+import lombok.extern.slf4j.Slf4j;
+import org.quizly.quizly.core.application.BaseRequest;
+import org.quizly.quizly.core.application.BaseResponse;
+import org.quizly.quizly.core.application.BaseService;
+import org.quizly.quizly.core.domain.entity.User;
+import org.quizly.quizly.core.domain.entity.User.Provider;
+import org.quizly.quizly.core.domain.entity.User.Role;
+import org.quizly.quizly.core.domain.repository.UserRepository;
+import org.quizly.quizly.core.exception.DomainException;
+import org.quizly.quizly.core.exception.error.BaseErrorCode;
+import org.quizly.quizly.core.notification.NotificationProvider;
+import org.quizly.quizly.core.notification.NotificationThreadRepository;
+import org.quizly.quizly.oauth.dto.response.OAuth2UserInfo;
+import org.quizly.quizly.oauth.message.SignupNotificationMessage;
+import org.quizly.quizly.oauth.service.RegisterOAuthUserService.RegisterOAuthUserRequest;
+import org.quizly.quizly.oauth.service.RegisterOAuthUserService.RegisterOAuthUserResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * OAuth 사용자 정보를 받아온 이후의 DB 조회·생성·수정만 담당하는 서비스.
+ *
+ * <p>외부 OAuth 통신({@code super.loadUser})은 {@link OAuth2LoginUserService}에서 트랜잭션 밖으로 수행하고,
+ * 이 서비스의 {@link #execute}만 트랜잭션으로 감싼다. 외부 응답 지연이 DB 커넥션 점유 시간에 영향을 주지 않도록 분리했다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RegisterOAuthUserService implements
+    BaseService<RegisterOAuthUserRequest, RegisterOAuthUserResponse> {
+
+    private final UserRepository userRepository;
+    private final NotificationProvider notificationProvider;
+    private final NotificationThreadRepository notificationThreadRepository;
+
+    @Override
+    @Transactional
+    public RegisterOAuthUserResponse execute(RegisterOAuthUserRequest request) {
+        OAuth2UserInfo oAuth2UserInfo = request.getOAuth2UserInfo();
+
+        Provider provider;
+        try {
+            provider = Provider.valueOf(oAuth2UserInfo.getProvider().toUpperCase());
+        } catch (IllegalArgumentException e) {
+            log.warn("[RegisterOAuthUserService] 지원하지 않는 Provider - provider: {}",
+                oAuth2UserInfo.getProvider());
+            return RegisterOAuthUserResponse.builder()
+                .success(false)
+                .errorCode(RegisterOAuthUserErrorCode.UNSUPPORTED_PROVIDER)
+                .build();
+        }
+
+        User user = userRepository.findByProviderId(oAuth2UserInfo.getProviderId())
+            .map(existUser -> updateUser(existUser, oAuth2UserInfo))
+            .orElseGet(() -> createUser(provider, oAuth2UserInfo));
+
+        return RegisterOAuthUserResponse.builder()
+            .user(user)
+            .build();
+    }
+
+    private User createUser(Provider provider, OAuth2UserInfo oAuth2UserInfo) {
+        User userEntity = new User();
+        userEntity.setProvider(provider);
+        userEntity.setProviderId(oAuth2UserInfo.getProviderId());
+        userEntity.setEmail(oAuth2UserInfo.getEmail());
+        userEntity.setName(oAuth2UserInfo.getNickname());
+        userEntity.setNickName(oAuth2UserInfo.getNickname());
+        userEntity.setRole(Role.USER);
+        User savedUser = userRepository.save(userEntity);
+
+        try {
+            long totalMemberCount = userRepository.count();
+            notificationProvider.send(new SignupNotificationMessage(savedUser, totalMemberCount))
+                .ifPresent(threadTs -> notificationThreadRepository.save(savedUser.getId(), threadTs));
+        } catch (Exception e) {
+            log.warn("[RegisterOAuthUserService] 회원가입 슬랙 알림 전송 실패. userId: {}", savedUser.getId(), e);
+        }
+        return savedUser;
+    }
+
+    private User updateUser(User user, OAuth2UserInfo oAuth2UserInfo) {
+        String newEmail = oAuth2UserInfo.getEmail();
+        String newName = oAuth2UserInfo.getNickname();
+
+        if (!Objects.equals(user.getEmail(), newEmail)) {
+            user.setEmail(newEmail);
+        }
+        if (!Objects.equals(user.getName(), newName)) {
+            user.setName(newName);
+        }
+        return user;
+    }
+
+    @Getter
+    @RequiredArgsConstructor
+    public enum RegisterOAuthUserErrorCode implements BaseErrorCode<DomainException> {
+        UNSUPPORTED_PROVIDER(HttpStatus.BAD_REQUEST, "지원하지 않는 소셜 로그인 Provider입니다.");
+
+        private final HttpStatus httpStatus;
+        private final String message;
+
+        @Override
+        public DomainException toException() {
+            return new DomainException(httpStatus, this);
+        }
+    }
+
+    @Getter
+    @Setter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @ToString
+    public static class RegisterOAuthUserRequest implements BaseRequest {
+
+        private OAuth2UserInfo oAuth2UserInfo;
+
+        @Override
+        public boolean isValid() {
+            return oAuth2UserInfo != null
+                && oAuth2UserInfo.getProvider() != null
+                && oAuth2UserInfo.getProviderId() != null;
+        }
+    }
+
+    @Getter
+    @Setter
+    @SuperBuilder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @ToString
+    public static class RegisterOAuthUserResponse extends BaseResponse<RegisterOAuthUserErrorCode> {
+
+        private User user;
+    }
+}


### PR DESCRIPTION
## 연관 이슈
- 이 PR이 해결하는 이슈: #180

## 작업 사항
- 소셜 로그인 1회에 동일 User를 3번 조회하던 문제를 1번으로 개선
    1. `updateUser()`에서 email/name이 실제로 변경된 경우에만 update 실행
    2. 로그 출력 용도로만 쓰이던 `findById(userId)` 제거 (userId는 이미 `UserPrincipal`에 존재)

## 테스트
- [X] 로컬 서버 테스트 완료

## 주의 사항 및 참고사항
- 