### PR TITLE
refactor(#182): slack 알림을 트랜잭션 비동기 처리

### DIFF
--- a/src/main/java/org/quizly/quizly/batch/listener/BatchFailureAlertListener.java
+++ b/src/main/java/org/quizly/quizly/batch/listener/BatchFailureAlertListener.java
@@ -2,20 +2,20 @@ package org.quizly.quizly.batch.listener;
 
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.quizly.quizly.batch.message.BatchFailureNotificationMessage;
+import org.quizly.quizly.core.notification.NotificationExecutor;
 import org.quizly.quizly.core.notification.NotificationProvider;
 import org.springframework.batch.core.BatchStatus;
 import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobExecutionListener;
 import org.springframework.stereotype.Component;
 
-@Slf4j
 @Component
 @RequiredArgsConstructor
 public class BatchFailureAlertListener implements JobExecutionListener {
 
     private final NotificationProvider notificationProvider;
+    private final NotificationExecutor notificationExecutor;
 
     @Override
     public void afterJob(JobExecution jobExecution) {
@@ -34,9 +34,9 @@ public class BatchFailureAlertListener implements JobExecutionListener {
 
             String parameters = formatJobParameters(jobExecution);
 
-            notificationProvider.send(
-                new BatchFailureNotificationMessage(jobName, reason, step, parameters)
-            );
+            notificationExecutor.runQuietly("BatchFailureAlertListener", () ->
+                notificationProvider.send(
+                    new BatchFailureNotificationMessage(jobName, reason, step, parameters)));
         }
     }
 

--- a/src/main/java/org/quizly/quizly/core/notification/NotificationExecutor.java
+++ b/src/main/java/org/quizly/quizly/core/notification/NotificationExecutor.java
@@ -1,0 +1,25 @@
+package org.quizly.quizly.core.notification;
+
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Component;
+
+@Log4j2
+@Component
+public class NotificationExecutor {
+
+    public void runQuietly(String context, Runnable task) {
+        runQuietly(context, null, task);
+    }
+
+    public void runQuietly(String context, Long referenceId, Runnable task) {
+        try {
+            task.run();
+        } catch (Exception e) {
+            if (referenceId == null) {
+                log.warn("[{}] 알림 전송 실패.", context, e);
+            } else {
+                log.warn("[{}] 알림 전송 실패. referenceId: {}", context, referenceId, e);
+            }
+        }
+    }
+}

--- a/src/main/java/org/quizly/quizly/oauth/event/UserSignedUpEvent.java
+++ b/src/main/java/org/quizly/quizly/oauth/event/UserSignedUpEvent.java
@@ -1,0 +1,7 @@
+package org.quizly.quizly.oauth.event;
+
+import org.quizly.quizly.core.domain.entity.User;
+
+public record UserSignedUpEvent(User user, long totalMemberCount) {
+
+}

--- a/src/main/java/org/quizly/quizly/oauth/listener/SignupNotificationListener.java
+++ b/src/main/java/org/quizly/quizly/oauth/listener/SignupNotificationListener.java
@@ -1,12 +1,12 @@
-package org.quizly.quizly.account.listener;
+package org.quizly.quizly.oauth.listener;
 
 import lombok.RequiredArgsConstructor;
-import org.quizly.quizly.account.event.OnboardingCompletedEvent;
-import org.quizly.quizly.account.message.OnboardingNotificationMessage;
 import org.quizly.quizly.core.domain.entity.User;
 import org.quizly.quizly.core.notification.NotificationExecutor;
 import org.quizly.quizly.core.notification.NotificationProvider;
 import org.quizly.quizly.core.notification.NotificationThreadRepository;
+import org.quizly.quizly.oauth.event.UserSignedUpEvent;
+import org.quizly.quizly.oauth.message.SignupNotificationMessage;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
@@ -14,7 +14,7 @@ import org.springframework.transaction.event.TransactionalEventListener;
 
 @Component
 @RequiredArgsConstructor
-public class OnboardingNotificationListener {
+public class SignupNotificationListener {
 
     private final NotificationProvider notificationProvider;
     private final NotificationThreadRepository notificationThreadRepository;
@@ -22,14 +22,12 @@ public class OnboardingNotificationListener {
 
     @Async("notificationTaskExecutor")
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    public void handle(OnboardingCompletedEvent event) {
+    public void handle(UserSignedUpEvent event) {
         User user = event.user();
         Long userId = user.getId();
 
-        notificationExecutor.runQuietly("OnboardingNotificationListener", userId, () -> {
-            String threadTs = notificationThreadRepository.find(userId).orElse(null);
-            notificationProvider.send(new OnboardingNotificationMessage(user, threadTs));
-            notificationThreadRepository.delete(userId);
-        });
+        notificationExecutor.runQuietly("SignupNotificationListener", userId, () ->
+            notificationProvider.send(new SignupNotificationMessage(user, event.totalMemberCount()))
+                .ifPresent(threadTs -> notificationThreadRepository.save(userId, threadTs)));
     }
 }

--- a/src/main/java/org/quizly/quizly/oauth/service/RegisterOAuthUserService.java
+++ b/src/main/java/org/quizly/quizly/oauth/service/RegisterOAuthUserService.java
@@ -19,12 +19,11 @@ import org.quizly.quizly.core.domain.entity.User.Role;
 import org.quizly.quizly.core.domain.repository.UserRepository;
 import org.quizly.quizly.core.exception.DomainException;
 import org.quizly.quizly.core.exception.error.BaseErrorCode;
-import org.quizly.quizly.core.notification.NotificationProvider;
-import org.quizly.quizly.core.notification.NotificationThreadRepository;
 import org.quizly.quizly.oauth.dto.response.OAuth2UserInfo;
-import org.quizly.quizly.oauth.message.SignupNotificationMessage;
+import org.quizly.quizly.oauth.event.UserSignedUpEvent;
 import org.quizly.quizly.oauth.service.RegisterOAuthUserService.RegisterOAuthUserRequest;
 import org.quizly.quizly.oauth.service.RegisterOAuthUserService.RegisterOAuthUserResponse;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -42,8 +41,7 @@ public class RegisterOAuthUserService implements
     BaseService<RegisterOAuthUserRequest, RegisterOAuthUserResponse> {
 
     private final UserRepository userRepository;
-    private final NotificationProvider notificationProvider;
-    private final NotificationThreadRepository notificationThreadRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Override
     @Transactional
@@ -81,13 +79,9 @@ public class RegisterOAuthUserService implements
         userEntity.setRole(Role.USER);
         User savedUser = userRepository.save(userEntity);
 
-        try {
-            long totalMemberCount = userRepository.count();
-            notificationProvider.send(new SignupNotificationMessage(savedUser, totalMemberCount))
-                .ifPresent(threadTs -> notificationThreadRepository.save(savedUser.getId(), threadTs));
-        } catch (Exception e) {
-            log.warn("[RegisterOAuthUserService] 회원가입 슬랙 알림 전송 실패. userId: {}", savedUser.getId(), e);
-        }
+        long totalMemberCount = userRepository.count();
+        eventPublisher.publishEvent(new UserSignedUpEvent(savedUser, totalMemberCount));
+
         return savedUser;
     }
 


### PR DESCRIPTION
## 연관 이슈
- 이 PR이 해결하는 이슈: #182

## 작업 사항
- 회원가입 슬랙 알림을 비동기 리스너로 전환
- 알림 전송 실패 처리를 `NotificationExecutor`로 공통화 (가입, 온보딩, 배치 리스너 적용)


## 테스트
- [x] 로컬 서버 테스트 완료

## 주의 사항 및 참고사항
- 