### PR TITLE
feat(#185): 5분 상식 퀴즈 도메인 및 어드민 API 구현

### DIFF
--- a/src/main/java/org/quizly/quizly/admin/controller/get/AdminReadDailyQuizController.java
+++ b/src/main/java/org/quizly/quizly/admin/controller/get/AdminReadDailyQuizController.java
@@ -1,0 +1,85 @@
+package org.quizly.quizly.admin.controller.get;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.quizly.quizly.admin.dto.response.AdminReadDailyQuizResponse;
+import org.quizly.quizly.admin.dto.response.AdminReadDailyQuizResponse.QuestionDetail;
+import org.quizly.quizly.admin.service.AdminReadDailyQuizService;
+import org.quizly.quizly.admin.service.AdminReadDailyQuizService.AdminReadDailyQuizErrorCode;
+import org.quizly.quizly.configuration.swagger.ApiErrorCode;
+import org.quizly.quizly.core.application.BaseResponse;
+import org.quizly.quizly.core.domain.entity.DailyQuiz;
+import org.quizly.quizly.core.exception.error.GlobalErrorCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "Admin", description = "관리자")
+public class AdminReadDailyQuizController {
+
+    private final AdminReadDailyQuizService adminReadDailyQuizService;
+
+    @Operation(
+        summary = "5분 상식 퀴즈 세트 상세 조회 API",
+        description = "관리자 전용 API로 5분 상식 퀴즈 세트 1건의 전체 내용을 조회합니다.\n\n"
+            + "- 수정 화면에서 현재 값을 채우기 위한 API로, 원본 자료와 문항 3개를 모두 포함합니다.\n"
+            + "- 미발행 세트도 조회할 수 있습니다.\n"
+            + "- 문항은 `questionNumber` 오름차순으로 반환됩니다.",
+        operationId = "/admin/daily-quizzes/{dailyQuizId}"
+    )
+    @GetMapping("/admin/daily-quizzes/{dailyQuizId}")
+    @PreAuthorize("hasRole('ADMIN')")
+    @ApiErrorCode(errorCodes = {GlobalErrorCode.class, AdminReadDailyQuizErrorCode.class})
+    public ResponseEntity<AdminReadDailyQuizResponse> adminReadDailyQuiz(
+        @PathVariable @Schema(description = "5분 상식 퀴즈 세트 ID", example = "1") Long dailyQuizId
+    ) {
+        AdminReadDailyQuizService.AdminReadDailyQuizResponse serviceResponse =
+            adminReadDailyQuizService.execute(
+                AdminReadDailyQuizService.AdminReadDailyQuizRequest.builder()
+                    .dailyQuizId(dailyQuizId)
+                    .build()
+            );
+
+        if (serviceResponse == null || !serviceResponse.isSuccess()) {
+            Optional.ofNullable(serviceResponse)
+                .map(BaseResponse::getErrorCode)
+                .ifPresentOrElse(errorCode -> {
+                    throw errorCode.toException();
+                }, () -> {
+                    throw GlobalErrorCode.INTERNAL_ERROR.toException();
+                });
+        }
+
+        return ResponseEntity.ok(toResponse(serviceResponse));
+    }
+
+    private AdminReadDailyQuizResponse toResponse(
+        AdminReadDailyQuizService.AdminReadDailyQuizResponse serviceResponse) {
+        DailyQuiz dailyQuiz = serviceResponse.getDailyQuiz();
+
+        return AdminReadDailyQuizResponse.builder()
+            .dailyQuizId(dailyQuiz.getId())
+            .topic(dailyQuiz.getTopic())
+            .published(dailyQuiz.getPublished())
+            .warmUp(dailyQuiz.getWarmUp())
+            .sourceContent(dailyQuiz.getSourceContent())
+            .questions(dailyQuiz.getQuestions().stream()
+                .map(question -> new QuestionDetail(
+                    question.getId(),
+                    question.getQuestionNumber(),
+                    question.getQuestionText(),
+                    question.getAnswer(),
+                    question.getExplanation()))
+                .toList())
+            .createdAt(dailyQuiz.getCreatedAt())
+            .updatedAt(dailyQuiz.getUpdatedAt())
+            .build();
+    }
+}

--- a/src/main/java/org/quizly/quizly/admin/controller/get/AdminReadDailyQuizzesController.java
+++ b/src/main/java/org/quizly/quizly/admin/controller/get/AdminReadDailyQuizzesController.java
@@ -1,0 +1,83 @@
+package org.quizly.quizly.admin.controller.get;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.quizly.quizly.admin.dto.request.AdminReadDailyQuizzesRequest;
+import org.quizly.quizly.admin.dto.response.AdminReadDailyQuizzesResponse;
+import org.quizly.quizly.admin.dto.response.AdminReadDailyQuizzesResponse.AdminDailyQuizDetail;
+import org.quizly.quizly.admin.service.AdminReadDailyQuizzesService;
+import org.quizly.quizly.admin.service.AdminReadDailyQuizzesService.AdminReadDailyQuizzesErrorCode;
+import org.quizly.quizly.configuration.swagger.ApiErrorCode;
+import org.quizly.quizly.core.application.BaseResponse;
+import org.quizly.quizly.core.domain.entity.DailyQuiz;
+import org.quizly.quizly.core.exception.error.GlobalErrorCode;
+import org.quizly.quizly.core.presentation.Pagination;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "Admin", description = "관리자")
+public class AdminReadDailyQuizzesController {
+
+    private final AdminReadDailyQuizzesService adminReadDailyQuizzesService;
+
+    @Operation(
+        summary = "5분 상식 퀴즈 세트 목록 조회 API",
+        description = "관리자 전용 API로 등록된 5분 상식 퀴즈 세트를 최신순으로 조회합니다.\n\n"
+            + "- `page`: 페이지 번호 (기본값 1)\n"
+            + "- `pageSize`: 페이지 크기 (기본값 10)\n"
+            + "- 발행 대상을 고를 때 사용합니다. `published`가 true인 세트가 조회 API 노출 대상입니다.",
+        operationId = "/admin/daily-quizzes"
+    )
+    @GetMapping("/admin/daily-quizzes")
+    @PreAuthorize("hasRole('ADMIN')")
+    @ApiErrorCode(errorCodes = {GlobalErrorCode.class, AdminReadDailyQuizzesErrorCode.class})
+    public ResponseEntity<AdminReadDailyQuizzesResponse> adminReadDailyQuizzes(
+        @ModelAttribute AdminReadDailyQuizzesRequest request
+    ) {
+        AdminReadDailyQuizzesService.AdminReadDailyQuizzesResponse serviceResponse =
+            adminReadDailyQuizzesService.execute(
+                AdminReadDailyQuizzesService.AdminReadDailyQuizzesRequest.builder()
+                    .pageRequest(request.toPageRequest())
+                    .build()
+            );
+
+        if (serviceResponse == null || !serviceResponse.isSuccess()) {
+            Optional.ofNullable(serviceResponse)
+                .map(BaseResponse::getErrorCode)
+                .ifPresentOrElse(errorCode -> {
+                    throw errorCode.toException();
+                }, () -> {
+                    throw GlobalErrorCode.INTERNAL_ERROR.toException();
+                });
+        }
+
+        return ResponseEntity.ok(
+            toResponse(serviceResponse.getDailyQuizList(), serviceResponse.getPagination()));
+    }
+
+    private AdminReadDailyQuizzesResponse toResponse(
+        List<DailyQuiz> dailyQuizList, Pagination pagination) {
+        List<AdminDailyQuizDetail> details = dailyQuizList.stream()
+            .map(dailyQuiz -> new AdminDailyQuizDetail(
+                dailyQuiz.getId(),
+                dailyQuiz.getTopic(),
+                dailyQuiz.getPublished(),
+                dailyQuiz.getWarmUp(),
+                dailyQuiz.getCreatedAt(),
+                dailyQuiz.getUpdatedAt()
+            )).toList();
+
+        return AdminReadDailyQuizzesResponse.builder()
+            .dailyQuizList(details)
+            .pagination(pagination)
+            .build();
+    }
+}

--- a/src/main/java/org/quizly/quizly/admin/controller/patch/UpdateDailyQuizController.java
+++ b/src/main/java/org/quizly/quizly/admin/controller/patch/UpdateDailyQuizController.java
@@ -1,0 +1,94 @@
+package org.quizly.quizly.admin.controller.patch;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.quizly.quizly.admin.dto.request.UpdateDailyQuizRequest;
+import org.quizly.quizly.admin.dto.response.UpdateDailyQuizResponse;
+import org.quizly.quizly.admin.dto.response.UpdateDailyQuizResponse.QuestionDetail;
+import org.quizly.quizly.admin.service.UpdateDailyQuizService;
+import org.quizly.quizly.admin.service.UpdateDailyQuizService.UpdateDailyQuizErrorCode;
+import org.quizly.quizly.configuration.swagger.ApiErrorCode;
+import org.quizly.quizly.core.application.BaseResponse;
+import org.quizly.quizly.core.domain.entity.DailyQuiz;
+import org.quizly.quizly.core.exception.error.GlobalErrorCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@Log4j2
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "Admin", description = "관리자")
+public class UpdateDailyQuizController {
+
+    private final UpdateDailyQuizService updateDailyQuizService;
+
+    @Operation(
+        summary = "5분 상식 퀴즈 세트 수정/발행 API",
+        description = "관리자 전용 API로 5분 상식 퀴즈 세트의 내용을 수정하거나 발행 상태를 전환합니다.\n\n"
+            + "- 전달한 필드만 반영되며, 생략한 필드는 기존 값을 유지합니다.\n"
+            + "- 발행 전환만 하려면 `{\"published\": true}` 만 전달하면 됩니다.\n"
+            + "- `questions`를 전달하면 기존 문항 3개를 통째로 교체합니다. "
+            + "생략하면 기존 문항이 그대로 유지됩니다.\n"
+            + "- 발행 중인 세트가 여러 개면 조회 API가 그중 하나를 무작위로 반환합니다.",
+        operationId = "/admin/daily-quizzes/{dailyQuizId}"
+    )
+    @PatchMapping("/admin/daily-quizzes/{dailyQuizId}")
+    @PreAuthorize("hasRole('ADMIN')")
+    @ApiErrorCode(errorCodes = {GlobalErrorCode.class, UpdateDailyQuizErrorCode.class})
+    public ResponseEntity<UpdateDailyQuizResponse> updateDailyQuiz(
+        @PathVariable @Schema(description = "5분 상식 퀴즈 세트 ID", example = "1") Long dailyQuizId,
+        @RequestBody UpdateDailyQuizRequest request
+    ) {
+        UpdateDailyQuizService.UpdateDailyQuizResponse serviceResponse = updateDailyQuizService.execute(
+            UpdateDailyQuizService.UpdateDailyQuizRequest.builder()
+                .dailyQuizId(dailyQuizId)
+                .topic(request.getTopic())
+                .warmUp(request.getWarmUp())
+                .sourceContent(request.getSourceContent())
+                .published(request.getPublished())
+                .questions(request.toQuestionCommands())
+                .build()
+        );
+
+        if (serviceResponse == null || !serviceResponse.isSuccess()) {
+            Optional.ofNullable(serviceResponse)
+                .map(BaseResponse::getErrorCode)
+                .ifPresentOrElse(errorCode -> {
+                    throw errorCode.toException();
+                }, () -> {
+                    throw GlobalErrorCode.INTERNAL_ERROR.toException();
+                });
+        }
+
+        return ResponseEntity.ok(toResponse(serviceResponse));
+    }
+
+    private UpdateDailyQuizResponse toResponse(
+        UpdateDailyQuizService.UpdateDailyQuizResponse serviceResponse) {
+        DailyQuiz dailyQuiz = serviceResponse.getDailyQuiz();
+
+        return UpdateDailyQuizResponse.builder()
+            .dailyQuizId(dailyQuiz.getId())
+            .topic(dailyQuiz.getTopic())
+            .published(dailyQuiz.getPublished())
+            .warmUp(dailyQuiz.getWarmUp())
+            .sourceContent(dailyQuiz.getSourceContent())
+            .questions(dailyQuiz.getQuestions().stream()
+                .map(question -> new QuestionDetail(
+                    question.getId(),
+                    question.getQuestionNumber(),
+                    question.getQuestionText(),
+                    question.getAnswer(),
+                    question.getExplanation()))
+                .toList())
+            .build();
+    }
+}

--- a/src/main/java/org/quizly/quizly/admin/controller/post/CreateDailyQuizController.java
+++ b/src/main/java/org/quizly/quizly/admin/controller/post/CreateDailyQuizController.java
@@ -1,0 +1,91 @@
+package org.quizly.quizly.admin.controller.post;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.quizly.quizly.admin.dto.request.CreateDailyQuizRequest;
+import org.quizly.quizly.admin.dto.response.CreateDailyQuizResponse;
+import org.quizly.quizly.admin.dto.response.CreateDailyQuizResponse.QuestionDetail;
+import org.quizly.quizly.admin.service.CreateDailyQuizService;
+import org.quizly.quizly.admin.service.CreateDailyQuizService.CreateDailyQuizErrorCode;
+import org.quizly.quizly.configuration.swagger.ApiErrorCode;
+import org.quizly.quizly.core.application.BaseResponse;
+import org.quizly.quizly.core.domain.entity.DailyQuiz;
+import org.quizly.quizly.core.exception.error.GlobalErrorCode;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@Log4j2
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "Admin", description = "관리자")
+public class CreateDailyQuizController {
+
+    private final CreateDailyQuizService createDailyQuizService;
+
+    @Operation(
+        summary = "5분 상식 퀴즈 세트 등록 API",
+        description = "관리자 전용 API로 주제별 5분 상식 퀴즈 세트를 등록합니다.\n\n"
+            + "- 5분 상식 퀴즈는 OX 문항만 지원합니다.\n"
+            + "- `questions`는 정확히 3개이며 `questionNumber`는 1~3을 중복 없이 사용합니다.\n"
+            + "- `answer`에 O 또는 X를 전달합니다. 저장 시 TRUE/FALSE로 정규화됩니다.\n"
+            + "- `published`를 true로 두면 등록 즉시 발행됩니다. 발행 중인 세트가 여러 개면 "
+            + "조회 API가 그중 하나를 무작위로 반환합니다.",
+        operationId = "/admin/daily-quizzes"
+    )
+    @PostMapping("/admin/daily-quizzes")
+    @PreAuthorize("hasRole('ADMIN')")
+    @ApiErrorCode(errorCodes = {GlobalErrorCode.class, CreateDailyQuizErrorCode.class})
+    public ResponseEntity<CreateDailyQuizResponse> createDailyQuiz(
+        @RequestBody CreateDailyQuizRequest request
+    ) {
+        CreateDailyQuizService.CreateDailyQuizResponse serviceResponse = createDailyQuizService.execute(
+            CreateDailyQuizService.CreateDailyQuizRequest.builder()
+                .topic(request.getTopic())
+                .warmUp(request.getWarmUp())
+                .sourceContent(request.getSourceContent())
+                .published(request.getPublished())
+                .questions(request.toQuestionCommands())
+                .build()
+        );
+
+        if (serviceResponse == null || !serviceResponse.isSuccess()) {
+            Optional.ofNullable(serviceResponse)
+                .map(BaseResponse::getErrorCode)
+                .ifPresentOrElse(errorCode -> {
+                    throw errorCode.toException();
+                }, () -> {
+                    throw GlobalErrorCode.INTERNAL_ERROR.toException();
+                });
+        }
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(toResponse(serviceResponse));
+    }
+
+    private CreateDailyQuizResponse toResponse(
+        CreateDailyQuizService.CreateDailyQuizResponse serviceResponse) {
+        DailyQuiz dailyQuiz = serviceResponse.getDailyQuiz();
+
+        return CreateDailyQuizResponse.builder()
+            .dailyQuizId(dailyQuiz.getId())
+            .topic(dailyQuiz.getTopic())
+            .published(dailyQuiz.getPublished())
+            .warmUp(dailyQuiz.getWarmUp())
+            .sourceContent(dailyQuiz.getSourceContent())
+            .questions(dailyQuiz.getQuestions().stream()
+                .map(question -> new QuestionDetail(
+                    question.getId(),
+                    question.getQuestionNumber(),
+                    question.getQuestionText(),
+                    question.getAnswer(),
+                    question.getExplanation()))
+                .toList())
+            .build();
+    }
+}

--- a/src/main/java/org/quizly/quizly/admin/dto/request/AdminReadDailyQuizzesRequest.java
+++ b/src/main/java/org/quizly/quizly/admin/dto/request/AdminReadDailyQuizzesRequest.java
@@ -1,0 +1,13 @@
+package org.quizly.quizly.admin.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
+import org.quizly.quizly.core.presentation.BasePaginationRequest;
+
+@Getter
+@Setter
+@Schema(description = "5분 상식 퀴즈 세트 목록 조회 요청")
+public class AdminReadDailyQuizzesRequest extends BasePaginationRequest {
+
+}

--- a/src/main/java/org/quizly/quizly/admin/dto/request/CreateDailyQuizRequest.java
+++ b/src/main/java/org/quizly/quizly/admin/dto/request/CreateDailyQuizRequest.java
@@ -1,0 +1,80 @@
+package org.quizly.quizly.admin.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.quizly.quizly.admin.support.DailyQuizQuestionCommand;
+import org.quizly.quizly.core.application.BaseRequest;
+
+@Getter
+@SuperBuilder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "5분 상식 퀴즈 세트 생성 요청")
+public class CreateDailyQuizRequest implements BaseRequest {
+
+    @Schema(description = "주제", example = "환경")
+    private String topic;
+
+    @Schema(
+        description = "문제 워밍업",
+        example = "탄소중립의 핵심으로 떠오른 이 기체를 아시나요? 뉴스에서는 자주 접했지만 헷갈렸던 환경 상식, "
+            + "Quizly AI가 준비한 3문항의 미니 OX 퀴즈로 가볍게 점검해보세요!"
+    )
+    private String warmUp;
+
+    @Schema(
+        description = "AI가 읽은 원본 자료",
+        example = "메탄은 이산화탄소에 이어 두 번째로 큰 온실효과를 일으키는 기체로, ..."
+    )
+    private String sourceContent;
+
+    @Schema(description = "발행 여부. 생략 시 false(미발행)로 생성됩니다.", example = "false")
+    private Boolean published;
+
+    @Schema(description = "문항 목록 (정확히 3개)")
+    private List<QuestionRequest> questions;
+
+    @Override
+    public boolean isValid() {
+        return topic != null && warmUp != null && sourceContent != null && questions != null;
+    }
+
+    public List<DailyQuizQuestionCommand> toQuestionCommands() {
+        if (questions == null) {
+            return null;
+        }
+
+        return questions.stream()
+            .map(question -> question == null ? null : DailyQuizQuestionCommand.builder()
+                .questionNumber(question.getQuestionNumber())
+                .questionText(question.getQuestionText())
+                .answer(question.getAnswer())
+                .explanation(question.getExplanation())
+                .build())
+            .toList();
+    }
+
+    @Getter
+    @SuperBuilder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "5분 상식 퀴즈 OX 문항")
+    public static class QuestionRequest {
+
+        @Schema(description = "문항 번호 (1~3)", example = "1")
+        private Integer questionNumber;
+
+        @Schema(description = "문항", example = "메탄은 이산화탄소보다 온실효과가 크다.")
+        private String questionText;
+
+        @Schema(description = "정답. O 또는 X (TRUE/FALSE도 허용)", example = "O")
+        private String answer;
+
+        @Schema(description = "해설", example = "메탄의 지구온난화지수는 이산화탄소의 약 28배입니다.")
+        private String explanation;
+    }
+}

--- a/src/main/java/org/quizly/quizly/admin/dto/request/UpdateDailyQuizRequest.java
+++ b/src/main/java/org/quizly/quizly/admin/dto/request/UpdateDailyQuizRequest.java
@@ -1,0 +1,68 @@
+package org.quizly.quizly.admin.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.quizly.quizly.admin.support.DailyQuizQuestionCommand;
+import org.quizly.quizly.core.application.BaseRequest;
+
+@Getter
+@SuperBuilder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "5분 상식 퀴즈 세트 수정 요청. 전달한 필드만 반영됩니다.")
+public class UpdateDailyQuizRequest implements BaseRequest {
+
+    @Schema(description = "주제. 생략 시 기존 값 유지", example = "환경")
+    private String topic;
+
+    @Schema(description = "문제 워밍업. 생략 시 기존 값 유지", example = "탄소중립의 핵심으로 떠오른 이 기체를 아시나요? ...")
+    private String warmUp;
+
+    @Schema(description = "AI가 읽은 원본 자료. 생략 시 기존 값 유지", example = "메탄은 이산화탄소에 이어 ...")
+    private String sourceContent;
+
+    @Schema(description = "발행 여부. 생략 시 기존 값 유지", example = "true")
+    private Boolean published;
+
+    @Schema(description = "문항 목록. 생략 시 기존 문항 유지, 전달 시 정확히 3개로 전체 교체")
+    private List<QuestionRequest> questions;
+
+    public List<DailyQuizQuestionCommand> toQuestionCommands() {
+        if (questions == null) {
+            return null;
+        }
+
+        return questions.stream()
+            .map(question -> question == null ? null : DailyQuizQuestionCommand.builder()
+                .questionNumber(question.getQuestionNumber())
+                .questionText(question.getQuestionText())
+                .answer(question.getAnswer())
+                .explanation(question.getExplanation())
+                .build())
+            .toList();
+    }
+
+    @Getter
+    @SuperBuilder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "5분 상식 퀴즈 OX 문항")
+    public static class QuestionRequest {
+
+        @Schema(description = "문항 번호 (1~3)", example = "1")
+        private Integer questionNumber;
+
+        @Schema(description = "문항", example = "메탄은 이산화탄소보다 온실효과가 크다.")
+        private String questionText;
+
+        @Schema(description = "정답. O 또는 X (TRUE/FALSE도 허용)", example = "O")
+        private String answer;
+
+        @Schema(description = "해설", example = "메탄의 지구온난화지수는 이산화탄소의 약 28배입니다.")
+        private String explanation;
+    }
+}

--- a/src/main/java/org/quizly/quizly/admin/dto/response/AdminReadDailyQuizResponse.java
+++ b/src/main/java/org/quizly/quizly/admin/dto/response/AdminReadDailyQuizResponse.java
@@ -1,0 +1,52 @@
+package org.quizly.quizly.admin.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.quizly.quizly.core.application.BaseResponse;
+import org.quizly.quizly.core.exception.error.GlobalErrorCode;
+
+@Getter
+@SuperBuilder
+@NoArgsConstructor
+@Schema(description = "5분 상식 퀴즈 세트 상세 조회 응답")
+public class AdminReadDailyQuizResponse extends BaseResponse<GlobalErrorCode> {
+
+    @Schema(description = "5분 상식 퀴즈 세트 ID", example = "1")
+    private Long dailyQuizId;
+
+    @Schema(description = "주제", example = "환경")
+    private String topic;
+
+    @Schema(description = "발행 여부", example = "true")
+    private Boolean published;
+
+    @Schema(description = "문제 워밍업", example = "탄소중립의 핵심으로 떠오른 이 기체를 아시나요? ...")
+    private String warmUp;
+
+    @Schema(description = "AI가 읽은 원본 자료", example = "메탄은 이산화탄소에 이어 ...")
+    private String sourceContent;
+
+    @Schema(description = "문항 목록 (문항 번호 오름차순)")
+    private List<QuestionDetail> questions;
+
+    @Schema(description = "생성일시", example = "2026-08-05T17:43:13")
+    private LocalDateTime createdAt;
+
+    @Schema(description = "수정일시", example = "2026-08-05T18:02:41")
+    private LocalDateTime updatedAt;
+
+    public record QuestionDetail(
+        @Schema(description = "문항 ID", example = "1") Long questionId,
+        @Schema(description = "문항 번호", example = "1") Integer questionNumber,
+        @Schema(description = "문항", example = "메탄은 이산화탄소보다 온실효과가 크다.") String questionText,
+        @Schema(description = "정답. TRUE 또는 FALSE", example = "TRUE") String answer,
+        @Schema(description = "해설", example = "메탄의 지구온난화지수는 이산화탄소의 약 28배입니다.")
+        String explanation
+    ) {
+
+    }
+}

--- a/src/main/java/org/quizly/quizly/admin/dto/response/AdminReadDailyQuizzesResponse.java
+++ b/src/main/java/org/quizly/quizly/admin/dto/response/AdminReadDailyQuizzesResponse.java
@@ -1,0 +1,36 @@
+package org.quizly.quizly.admin.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.quizly.quizly.core.application.BaseResponse;
+import org.quizly.quizly.core.exception.error.GlobalErrorCode;
+import org.quizly.quizly.core.presentation.Pagination;
+
+@Getter
+@SuperBuilder
+@NoArgsConstructor
+@Schema(description = "5분 상식 퀴즈 세트 목록 조회 응답")
+public class AdminReadDailyQuizzesResponse extends BaseResponse<GlobalErrorCode> {
+
+    @Schema(description = "세트 목록 (최신순)")
+    private List<AdminDailyQuizDetail> dailyQuizList;
+
+    @Schema(description = "페이지네이션")
+    private Pagination pagination;
+
+    public record AdminDailyQuizDetail(
+        @Schema(description = "5분 상식 퀴즈 세트 ID", example = "1") Long dailyQuizId,
+        @Schema(description = "주제", example = "환경") String topic,
+        @Schema(description = "발행 여부", example = "true") Boolean published,
+        @Schema(description = "문제 워밍업", example = "탄소중립의 핵심으로 떠오른 이 기체를 아시나요? ...")
+        String warmUp,
+        @Schema(description = "생성일시", example = "2026-08-05T17:43:13") LocalDateTime createdAt,
+        @Schema(description = "수정일시", example = "2026-08-05T18:02:41") LocalDateTime updatedAt
+    ) {
+
+    }
+}

--- a/src/main/java/org/quizly/quizly/admin/dto/response/CreateDailyQuizResponse.java
+++ b/src/main/java/org/quizly/quizly/admin/dto/response/CreateDailyQuizResponse.java
@@ -1,0 +1,45 @@
+package org.quizly.quizly.admin.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.quizly.quizly.core.application.BaseResponse;
+import org.quizly.quizly.core.exception.error.GlobalErrorCode;
+
+@Getter
+@SuperBuilder
+@NoArgsConstructor
+@Schema(description = "5분 상식 퀴즈 세트 생성 응답")
+public class CreateDailyQuizResponse extends BaseResponse<GlobalErrorCode> {
+
+    @Schema(description = "5분 상식 퀴즈 세트 ID", example = "1")
+    private Long dailyQuizId;
+
+    @Schema(description = "주제", example = "환경")
+    private String topic;
+
+    @Schema(description = "발행 여부", example = "false")
+    private Boolean published;
+
+    @Schema(description = "문제 워밍업", example = "탄소중립의 핵심으로 떠오른 이 기체를 아시나요? ...")
+    private String warmUp;
+
+    @Schema(description = "AI가 읽은 원본 자료", example = "메탄은 이산화탄소에 이어 ...")
+    private String sourceContent;
+
+    @Schema(description = "문항 목록")
+    private List<QuestionDetail> questions;
+
+    public record QuestionDetail(
+        @Schema(description = "문항 ID", example = "1") Long questionId,
+        @Schema(description = "문항 번호", example = "1") Integer questionNumber,
+        @Schema(description = "문항", example = "메탄은 이산화탄소보다 온실효과가 크다.") String questionText,
+        @Schema(description = "정답. TRUE 또는 FALSE", example = "TRUE") String answer,
+        @Schema(description = "해설", example = "메탄의 지구온난화지수는 이산화탄소의 약 28배입니다.")
+        String explanation
+    ) {
+
+    }
+}

--- a/src/main/java/org/quizly/quizly/admin/dto/response/UpdateDailyQuizResponse.java
+++ b/src/main/java/org/quizly/quizly/admin/dto/response/UpdateDailyQuizResponse.java
@@ -1,0 +1,45 @@
+package org.quizly.quizly.admin.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.quizly.quizly.core.application.BaseResponse;
+import org.quizly.quizly.core.exception.error.GlobalErrorCode;
+
+@Getter
+@SuperBuilder
+@NoArgsConstructor
+@Schema(description = "5분 상식 퀴즈 세트 수정 응답")
+public class UpdateDailyQuizResponse extends BaseResponse<GlobalErrorCode> {
+
+    @Schema(description = "5분 상식 퀴즈 세트 ID", example = "1")
+    private Long dailyQuizId;
+
+    @Schema(description = "주제", example = "환경")
+    private String topic;
+
+    @Schema(description = "발행 여부", example = "true")
+    private Boolean published;
+
+    @Schema(description = "문제 워밍업", example = "탄소중립의 핵심으로 떠오른 이 기체를 아시나요? ...")
+    private String warmUp;
+
+    @Schema(description = "AI가 읽은 원본 자료", example = "메탄은 이산화탄소에 이어 ...")
+    private String sourceContent;
+
+    @Schema(description = "문항 목록")
+    private List<QuestionDetail> questions;
+
+    public record QuestionDetail(
+        @Schema(description = "문항 ID", example = "1") Long questionId,
+        @Schema(description = "문항 번호", example = "1") Integer questionNumber,
+        @Schema(description = "문항", example = "메탄은 이산화탄소보다 온실효과가 크다.") String questionText,
+        @Schema(description = "정답. TRUE 또는 FALSE", example = "TRUE") String answer,
+        @Schema(description = "해설", example = "메탄의 지구온난화지수는 이산화탄소의 약 28배입니다.")
+        String explanation
+    ) {
+
+    }
+}

--- a/src/main/java/org/quizly/quizly/admin/service/AdminReadDailyQuizService.java
+++ b/src/main/java/org/quizly/quizly/admin/service/AdminReadDailyQuizService.java
@@ -1,0 +1,90 @@
+package org.quizly.quizly.admin.service;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.quizly.quizly.admin.service.AdminReadDailyQuizService.AdminReadDailyQuizRequest;
+import org.quizly.quizly.admin.service.AdminReadDailyQuizService.AdminReadDailyQuizResponse;
+import org.quizly.quizly.core.application.BaseRequest;
+import org.quizly.quizly.core.application.BaseResponse;
+import org.quizly.quizly.core.application.BaseService;
+import org.quizly.quizly.core.domain.entity.DailyQuiz;
+import org.quizly.quizly.core.domain.repository.DailyQuizRepository;
+import org.quizly.quizly.core.exception.DomainException;
+import org.quizly.quizly.core.exception.error.BaseErrorCode;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminReadDailyQuizService implements
+    BaseService<AdminReadDailyQuizRequest, AdminReadDailyQuizResponse> {
+
+    private final DailyQuizRepository dailyQuizRepository;
+
+    @Override
+    public AdminReadDailyQuizResponse execute(AdminReadDailyQuizRequest request) {
+        if (request == null || !request.isValid()) {
+            return AdminReadDailyQuizResponse.builder()
+                .success(false)
+                .errorCode(AdminReadDailyQuizErrorCode.NOT_EXIST_REQUIRED_PARAMETER)
+                .build();
+        }
+
+        DailyQuiz dailyQuiz = dailyQuizRepository
+            .findByIdAndDeletedFalse(request.getDailyQuizId())
+            .orElse(null);
+
+        if (dailyQuiz == null) {
+            return AdminReadDailyQuizResponse.builder()
+                .success(false)
+                .errorCode(AdminReadDailyQuizErrorCode.NOT_FOUND_DAILY_QUIZ)
+                .build();
+        }
+
+        dailyQuiz.getQuestions().size();
+
+        return AdminReadDailyQuizResponse.builder()
+            .dailyQuiz(dailyQuiz)
+            .build();
+    }
+
+    @Getter
+    @RequiredArgsConstructor
+    public enum AdminReadDailyQuizErrorCode implements BaseErrorCode<DomainException> {
+
+        NOT_EXIST_REQUIRED_PARAMETER(HttpStatus.BAD_REQUEST, "필수 파라미터가 누락되었습니다."),
+        NOT_FOUND_DAILY_QUIZ(HttpStatus.NOT_FOUND, "5분 상식 퀴즈를 찾을 수 없습니다.");
+
+        private final HttpStatus httpStatus;
+        private final String message;
+
+        @Override
+        public DomainException toException() {
+            return new DomainException(httpStatus, this);
+        }
+    }
+
+    @Getter
+    @Builder
+    public static class AdminReadDailyQuizRequest implements BaseRequest {
+
+        private Long dailyQuizId;
+
+        @Override
+        public boolean isValid() {
+            return dailyQuizId != null;
+        }
+    }
+
+    @Getter
+    @SuperBuilder
+    public static class AdminReadDailyQuizResponse
+        extends BaseResponse<AdminReadDailyQuizErrorCode> {
+
+        private DailyQuiz dailyQuiz;
+    }
+}

--- a/src/main/java/org/quizly/quizly/admin/service/AdminReadDailyQuizzesService.java
+++ b/src/main/java/org/quizly/quizly/admin/service/AdminReadDailyQuizzesService.java
@@ -1,0 +1,91 @@
+package org.quizly.quizly.admin.service;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.quizly.quizly.admin.service.AdminReadDailyQuizzesService.AdminReadDailyQuizzesRequest;
+import org.quizly.quizly.admin.service.AdminReadDailyQuizzesService.AdminReadDailyQuizzesResponse;
+import org.quizly.quizly.core.application.BaseRequest;
+import org.quizly.quizly.core.application.BaseResponse;
+import org.quizly.quizly.core.application.BaseService;
+import org.quizly.quizly.core.domain.entity.DailyQuiz;
+import org.quizly.quizly.core.domain.repository.DailyQuizRepository;
+import org.quizly.quizly.core.exception.DomainException;
+import org.quizly.quizly.core.exception.error.BaseErrorCode;
+import org.quizly.quizly.core.presentation.Pagination;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminReadDailyQuizzesService implements
+    BaseService<AdminReadDailyQuizzesRequest, AdminReadDailyQuizzesResponse> {
+
+    private static final String SORT_BY_LATEST = "createdAt";
+
+    private final DailyQuizRepository dailyQuizRepository;
+
+    @Override
+    public AdminReadDailyQuizzesResponse execute(AdminReadDailyQuizzesRequest request) {
+        if (request == null || !request.isValid()) {
+            return AdminReadDailyQuizzesResponse.builder()
+                .success(false)
+                .errorCode(AdminReadDailyQuizzesErrorCode.NOT_EXIST_REQUIRED_PARAMETER)
+                .build();
+        }
+
+        Pageable pageRequest = request.getPageRequest()
+            .withSort(Sort.by(Sort.Direction.DESC, SORT_BY_LATEST));
+
+        Page<DailyQuiz> dailyQuizPage = dailyQuizRepository.findAllByDeletedFalse(pageRequest);
+
+        return AdminReadDailyQuizzesResponse.builder()
+            .dailyQuizList(dailyQuizPage.getContent())
+            .pagination(Pagination.getPaginationFromPage(dailyQuizPage))
+            .build();
+    }
+
+    @Getter
+    @RequiredArgsConstructor
+    public enum AdminReadDailyQuizzesErrorCode implements BaseErrorCode<DomainException> {
+
+        NOT_EXIST_REQUIRED_PARAMETER(HttpStatus.BAD_REQUEST, "요청 파라미터가 존재하지 않습니다.");
+
+        private final HttpStatus httpStatus;
+        private final String message;
+
+        @Override
+        public DomainException toException() {
+            return new DomainException(httpStatus, this);
+        }
+    }
+
+    @Getter
+    @Builder
+    public static class AdminReadDailyQuizzesRequest implements BaseRequest {
+
+        private PageRequest pageRequest;
+
+        @Override
+        public boolean isValid() {
+            return pageRequest != null;
+        }
+    }
+
+    @Getter
+    @SuperBuilder
+    public static class AdminReadDailyQuizzesResponse
+        extends BaseResponse<AdminReadDailyQuizzesErrorCode> {
+
+        private List<DailyQuiz> dailyQuizList;
+        private Pagination pagination;
+    }
+}

--- a/src/main/java/org/quizly/quizly/admin/service/CreateDailyQuizService.java
+++ b/src/main/java/org/quizly/quizly/admin/service/CreateDailyQuizService.java
@@ -1,0 +1,123 @@
+package org.quizly.quizly.admin.service;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import lombok.extern.log4j.Log4j2;
+import org.quizly.quizly.admin.service.CreateDailyQuizService.CreateDailyQuizRequest;
+import org.quizly.quizly.admin.service.CreateDailyQuizService.CreateDailyQuizResponse;
+import org.quizly.quizly.admin.support.DailyQuizQuestionCommand;
+import org.quizly.quizly.admin.support.DailyQuizQuestionValidator;
+import org.quizly.quizly.admin.support.DailyQuizQuestionValidator.Result;
+import org.quizly.quizly.core.application.BaseRequest;
+import org.quizly.quizly.core.application.BaseResponse;
+import org.quizly.quizly.core.application.BaseService;
+import org.quizly.quizly.core.domain.entity.DailyQuiz;
+import org.quizly.quizly.core.domain.repository.DailyQuizRepository;
+import org.quizly.quizly.core.exception.DomainException;
+import org.quizly.quizly.core.exception.error.BaseErrorCode;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Log4j2
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CreateDailyQuizService implements
+    BaseService<CreateDailyQuizRequest, CreateDailyQuizResponse> {
+
+    private final DailyQuizRepository dailyQuizRepository;
+    private final DailyQuizQuestionValidator dailyQuizQuestionValidator;
+
+    @Override
+    public CreateDailyQuizResponse execute(CreateDailyQuizRequest request) {
+        if (request == null || !request.isValid()) {
+            return fail(CreateDailyQuizErrorCode.NOT_EXIST_REQUIRED_PARAMETER);
+        }
+
+        Result validationResult = dailyQuizQuestionValidator.validate(request.getQuestions());
+        if (validationResult.hasViolation()) {
+            return fail(toErrorCode(validationResult.getViolation()));
+        }
+
+        DailyQuiz dailyQuiz = DailyQuiz.builder()
+            .topic(request.getTopic())
+            .warmUp(request.getWarmUp())
+            .sourceContent(request.getSourceContent())
+            .published(request.getPublished() != null && request.getPublished())
+            .build();
+        dailyQuiz.replaceQuestions(validationResult.getQuestions());
+
+        DailyQuiz savedDailyQuiz = dailyQuizRepository.save(dailyQuiz);
+
+        log.info("[CreateDailyQuizService] 5분 상식 퀴즈 생성 완료 dailyQuizId={}, topic={}, published={}",
+            savedDailyQuiz.getId(), savedDailyQuiz.getTopic(), savedDailyQuiz.getPublished());
+
+        return CreateDailyQuizResponse.builder()
+            .dailyQuiz(savedDailyQuiz)
+            .build();
+    }
+
+    private CreateDailyQuizResponse fail(CreateDailyQuizErrorCode errorCode) {
+        return CreateDailyQuizResponse.builder()
+            .success(false)
+            .errorCode(errorCode)
+            .build();
+    }
+
+    private CreateDailyQuizErrorCode toErrorCode(DailyQuizQuestionValidator.Violation violation) {
+        return switch (violation) {
+            case INVALID_QUESTION_COUNT -> CreateDailyQuizErrorCode.INVALID_QUESTION_COUNT;
+            case INVALID_QUESTION_NUMBER -> CreateDailyQuizErrorCode.INVALID_QUESTION_NUMBER;
+            case INVALID_TRUE_FALSE_ANSWER -> CreateDailyQuizErrorCode.INVALID_TRUE_FALSE_ANSWER;
+            case NOT_EXIST_REQUIRED_PARAMETER ->
+                CreateDailyQuizErrorCode.NOT_EXIST_REQUIRED_PARAMETER;
+        };
+    }
+
+    @Getter
+    @RequiredArgsConstructor
+    public enum CreateDailyQuizErrorCode implements BaseErrorCode<DomainException> {
+
+        NOT_EXIST_REQUIRED_PARAMETER(HttpStatus.BAD_REQUEST, "필수 파라미터가 누락되었습니다."),
+        INVALID_QUESTION_COUNT(HttpStatus.BAD_REQUEST, "문항은 3개여야 합니다."),
+        INVALID_QUESTION_NUMBER(HttpStatus.BAD_REQUEST, "문항 번호는 1부터 3까지 중복 없이 지정해야 합니다."),
+        INVALID_TRUE_FALSE_ANSWER(HttpStatus.BAD_REQUEST, "OX 문항의 정답은 O 또는 X여야 합니다.");
+
+        private final HttpStatus httpStatus;
+        private final String message;
+
+        @Override
+        public DomainException toException() {
+            return new DomainException(httpStatus, this);
+        }
+    }
+
+    @Getter
+    @Builder
+    public static class CreateDailyQuizRequest implements BaseRequest {
+
+        private String topic;
+        private String warmUp;
+        private String sourceContent;
+        private Boolean published;
+        private List<DailyQuizQuestionCommand> questions;
+
+        @Override
+        public boolean isValid() {
+            return topic != null && !topic.isBlank()
+                && warmUp != null && !warmUp.isBlank()
+                && sourceContent != null && !sourceContent.isBlank();
+        }
+    }
+
+    @Getter
+    @SuperBuilder
+    public static class CreateDailyQuizResponse extends BaseResponse<CreateDailyQuizErrorCode> {
+
+        private DailyQuiz dailyQuiz;
+    }
+}

--- a/src/main/java/org/quizly/quizly/admin/service/UpdateDailyQuizService.java
+++ b/src/main/java/org/quizly/quizly/admin/service/UpdateDailyQuizService.java
@@ -1,0 +1,149 @@
+package org.quizly.quizly.admin.service;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import lombok.extern.log4j.Log4j2;
+import org.quizly.quizly.admin.service.UpdateDailyQuizService.UpdateDailyQuizRequest;
+import org.quizly.quizly.admin.service.UpdateDailyQuizService.UpdateDailyQuizResponse;
+import org.quizly.quizly.admin.support.DailyQuizQuestionCommand;
+import org.quizly.quizly.admin.support.DailyQuizQuestionValidator;
+import org.quizly.quizly.admin.support.DailyQuizQuestionValidator.Result;
+import org.quizly.quizly.core.application.BaseRequest;
+import org.quizly.quizly.core.application.BaseResponse;
+import org.quizly.quizly.core.application.BaseService;
+import org.quizly.quizly.core.domain.entity.DailyQuiz;
+import org.quizly.quizly.core.domain.entity.DailyQuizQuestion;
+import org.quizly.quizly.core.domain.repository.DailyQuizRepository;
+import org.quizly.quizly.core.exception.DomainException;
+import org.quizly.quizly.core.exception.error.BaseErrorCode;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Log4j2
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class UpdateDailyQuizService implements
+    BaseService<UpdateDailyQuizRequest, UpdateDailyQuizResponse> {
+
+    private final DailyQuizRepository dailyQuizRepository;
+    private final DailyQuizQuestionValidator dailyQuizQuestionValidator;
+
+    @Override
+    public UpdateDailyQuizResponse execute(UpdateDailyQuizRequest request) {
+        if (request == null || !request.isValid()) {
+            return fail(UpdateDailyQuizErrorCode.NOT_EXIST_REQUIRED_PARAMETER);
+        }
+
+        DailyQuiz dailyQuiz = dailyQuizRepository
+            .findByIdAndDeletedFalse(request.getDailyQuizId())
+            .orElse(null);
+
+        if (dailyQuiz == null) {
+            return fail(UpdateDailyQuizErrorCode.NOT_FOUND_DAILY_QUIZ);
+        }
+
+        List<DailyQuizQuestion> validatedQuestions = null;
+        if (request.getQuestions() != null) {
+            Result validationResult = dailyQuizQuestionValidator.validate(request.getQuestions());
+            if (validationResult.hasViolation()) {
+                return fail(toErrorCode(validationResult.getViolation()));
+            }
+            validatedQuestions = validationResult.getQuestions();
+        }
+
+        dailyQuiz.update(request.getTopic(), request.getWarmUp(), request.getSourceContent(),
+            request.getPublished());
+
+        if (validatedQuestions != null) {
+            dailyQuiz.replaceQuestions(validatedQuestions);
+            dailyQuizRepository.flush();
+        }
+
+        dailyQuiz.getQuestions().size();
+
+        log.info("[UpdateDailyQuizService] 5분 상식 퀴즈 수정 완료 dailyQuizId={}, published={}",
+            dailyQuiz.getId(), dailyQuiz.getPublished());
+
+        return UpdateDailyQuizResponse.builder()
+            .dailyQuiz(dailyQuiz)
+            .build();
+    }
+
+    private UpdateDailyQuizResponse fail(UpdateDailyQuizErrorCode errorCode) {
+        return UpdateDailyQuizResponse.builder()
+            .success(false)
+            .errorCode(errorCode)
+            .build();
+    }
+
+    private UpdateDailyQuizErrorCode toErrorCode(DailyQuizQuestionValidator.Violation violation) {
+        return switch (violation) {
+            case INVALID_QUESTION_COUNT -> UpdateDailyQuizErrorCode.INVALID_QUESTION_COUNT;
+            case INVALID_QUESTION_NUMBER -> UpdateDailyQuizErrorCode.INVALID_QUESTION_NUMBER;
+            case INVALID_TRUE_FALSE_ANSWER -> UpdateDailyQuizErrorCode.INVALID_TRUE_FALSE_ANSWER;
+            case NOT_EXIST_REQUIRED_PARAMETER ->
+                UpdateDailyQuizErrorCode.NOT_EXIST_REQUIRED_PARAMETER;
+        };
+    }
+
+    @Getter
+    @RequiredArgsConstructor
+    public enum UpdateDailyQuizErrorCode implements BaseErrorCode<DomainException> {
+
+        NOT_EXIST_REQUIRED_PARAMETER(HttpStatus.BAD_REQUEST, "필수 파라미터가 누락되었습니다."),
+        INVALID_QUESTION_COUNT(HttpStatus.BAD_REQUEST, "문항은 3개여야 합니다."),
+        INVALID_QUESTION_NUMBER(HttpStatus.BAD_REQUEST, "문항 번호는 1부터 3까지 중복 없이 지정해야 합니다."),
+        INVALID_TRUE_FALSE_ANSWER(HttpStatus.BAD_REQUEST, "OX 문항의 정답은 O 또는 X여야 합니다."),
+        NOT_FOUND_DAILY_QUIZ(HttpStatus.NOT_FOUND, "5분 상식 퀴즈를 찾을 수 없습니다.");
+
+        private final HttpStatus httpStatus;
+        private final String message;
+
+        @Override
+        public DomainException toException() {
+            return new DomainException(httpStatus, this);
+        }
+    }
+
+    @Getter
+    @Builder
+    public static class UpdateDailyQuizRequest implements BaseRequest {
+
+        private Long dailyQuizId;
+        private String topic;
+        private String warmUp;
+        private String sourceContent;
+        private Boolean published;
+        private List<DailyQuizQuestionCommand> questions;
+
+        @Override
+        public boolean isValid() {
+            return dailyQuizId != null
+                && hasAnyField()
+                && isNotBlankIfPresent(topic)
+                && isNotBlankIfPresent(warmUp)
+                && isNotBlankIfPresent(sourceContent);
+        }
+
+        private boolean hasAnyField() {
+            return topic != null || warmUp != null || sourceContent != null
+                || published != null || questions != null;
+        }
+
+        private boolean isNotBlankIfPresent(String value) {
+            return value == null || !value.isBlank();
+        }
+    }
+
+    @Getter
+    @SuperBuilder
+    public static class UpdateDailyQuizResponse extends BaseResponse<UpdateDailyQuizErrorCode> {
+
+        private DailyQuiz dailyQuiz;
+    }
+}

--- a/src/main/java/org/quizly/quizly/admin/support/DailyQuizQuestionCommand.java
+++ b/src/main/java/org/quizly/quizly/admin/support/DailyQuizQuestionCommand.java
@@ -1,0 +1,20 @@
+package org.quizly.quizly.admin.support;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class DailyQuizQuestionCommand {
+
+    private Integer questionNumber;
+    private String questionText;
+    private String answer;
+    private String explanation;
+
+    public boolean isValid() {
+        return questionText != null && !questionText.isBlank()
+            && answer != null && !answer.isBlank()
+            && explanation != null && !explanation.isBlank();
+    }
+}

--- a/src/main/java/org/quizly/quizly/admin/support/DailyQuizQuestionValidator.java
+++ b/src/main/java/org/quizly/quizly/admin/support/DailyQuizQuestionValidator.java
@@ -1,0 +1,101 @@
+package org.quizly.quizly.admin.support;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import lombok.Builder;
+import lombok.Getter;
+import org.quizly.quizly.core.domain.entity.DailyQuizQuestion;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DailyQuizQuestionValidator {
+
+    public static final int REQUIRED_QUESTION_COUNT = 3;
+
+    private static final String TRUE_ANSWER = "TRUE";
+    private static final String FALSE_ANSWER = "FALSE";
+
+    public Result validate(List<DailyQuizQuestionCommand> questions) {
+        if (questions == null || questions.stream().anyMatch(
+            question -> question == null || !question.isValid())) {
+            return Result.violated(Violation.NOT_EXIST_REQUIRED_PARAMETER);
+        }
+
+        if (questions.size() != REQUIRED_QUESTION_COUNT) {
+            return Result.violated(Violation.INVALID_QUESTION_COUNT);
+        }
+
+        if (!hasSequentialQuestionNumbers(questions)) {
+            return Result.violated(Violation.INVALID_QUESTION_NUMBER);
+        }
+
+        List<DailyQuizQuestion> validatedQuestions = new ArrayList<>();
+        for (DailyQuizQuestionCommand question : questions) {
+            String normalizedAnswer = normalizeTrueFalseAnswer(question.getAnswer());
+            if (normalizedAnswer == null) {
+                return Result.violated(Violation.INVALID_TRUE_FALSE_ANSWER);
+            }
+
+            validatedQuestions.add(DailyQuizQuestion.builder()
+                .questionNumber(question.getQuestionNumber())
+                .questionText(question.getQuestionText())
+                .answer(normalizedAnswer)
+                .explanation(question.getExplanation())
+                .build());
+        }
+
+        validatedQuestions.sort(
+            (left, right) -> Integer.compare(left.getQuestionNumber(), right.getQuestionNumber()));
+
+        return Result.builder().questions(validatedQuestions).build();
+    }
+
+    private boolean hasSequentialQuestionNumbers(List<DailyQuizQuestionCommand> questions) {
+        Set<Integer> questionNumbers = new HashSet<>();
+        for (DailyQuizQuestionCommand question : questions) {
+            Integer questionNumber = question.getQuestionNumber();
+            if (questionNumber == null || questionNumber < 1
+                || questionNumber > REQUIRED_QUESTION_COUNT) {
+                return false;
+            }
+            questionNumbers.add(questionNumber);
+        }
+        return questionNumbers.size() == REQUIRED_QUESTION_COUNT;
+    }
+
+    private String normalizeTrueFalseAnswer(String answer) {
+        String normalized = answer.trim().toUpperCase();
+        if (normalized.equals("O") || normalized.equals(TRUE_ANSWER)) {
+            return TRUE_ANSWER;
+        }
+        if (normalized.equals("X") || normalized.equals(FALSE_ANSWER)) {
+            return FALSE_ANSWER;
+        }
+        return null;
+    }
+
+    public enum Violation {
+        NOT_EXIST_REQUIRED_PARAMETER,
+        INVALID_QUESTION_COUNT,
+        INVALID_QUESTION_NUMBER,
+        INVALID_TRUE_FALSE_ANSWER
+    }
+
+    @Getter
+    @Builder
+    public static class Result {
+
+        private Violation violation;
+        private List<DailyQuizQuestion> questions;
+
+        private static Result violated(Violation violation) {
+            return Result.builder().violation(violation).build();
+        }
+
+        public boolean hasViolation() {
+            return violation != null;
+        }
+    }
+}

--- a/src/main/java/org/quizly/quizly/core/domain/entity/DailyQuiz.java
+++ b/src/main/java/org/quizly/quizly/core/domain/entity/DailyQuiz.java
@@ -1,0 +1,70 @@
+package org.quizly.quizly.core.domain.entity;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderBy;
+import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+import org.quizly.quizly.core.domain.shared.BaseEntity;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@SuperBuilder
+@Entity
+@Table(name = "daily_quiz")
+public class DailyQuiz extends BaseEntity {
+
+    @Column(nullable = false)
+    private String topic;
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String warmUp;
+
+    @Column(columnDefinition = "LONGTEXT", nullable = false)
+    private String sourceContent;
+
+    @Builder.Default
+    @Column(nullable = false)
+    private Boolean published = false;
+
+    @Builder.Default
+    @OneToMany(mappedBy = "dailyQuiz", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OrderBy("questionNumber ASC")
+    private List<DailyQuizQuestion> questions = new ArrayList<>();
+
+    public void replaceQuestions(List<DailyQuizQuestion> newQuestions) {
+        questions.clear();
+        newQuestions.forEach(question -> question.setDailyQuiz(this));
+        questions.addAll(newQuestions);
+    }
+
+    public void update(String topic, String warmUp, String sourceContent, Boolean published) {
+        if (topic != null) {
+            this.topic = topic;
+        }
+        if (warmUp != null) {
+            this.warmUp = warmUp;
+        }
+        if (sourceContent != null) {
+            this.sourceContent = sourceContent;
+        }
+        if (published != null) {
+            this.published = published;
+        }
+    }
+
+    public void softDelete() {
+        setDeleted(true);
+    }
+}

--- a/src/main/java/org/quizly/quizly/core/domain/entity/DailyQuizQuestion.java
+++ b/src/main/java/org/quizly/quizly/core/domain/entity/DailyQuizQuestion.java
@@ -1,0 +1,40 @@
+package org.quizly.quizly.core.domain.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+import org.quizly.quizly.core.domain.shared.BaseEntity;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@SuperBuilder
+@Entity
+@Table(name = "daily_quiz_question")
+public class DailyQuizQuestion extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "daily_quiz_id", nullable = false)
+    private DailyQuiz dailyQuiz;
+
+    @Column(nullable = false)
+    private Integer questionNumber;
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String questionText;
+
+    @Column(nullable = false)
+    private String answer;
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String explanation;
+}

--- a/src/main/java/org/quizly/quizly/core/domain/repository/DailyQuizRepository.java
+++ b/src/main/java/org/quizly/quizly/core/domain/repository/DailyQuizRepository.java
@@ -1,0 +1,14 @@
+package org.quizly.quizly.core.domain.repository;
+
+import java.util.Optional;
+import org.quizly.quizly.core.domain.entity.DailyQuiz;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DailyQuizRepository extends JpaRepository<DailyQuiz, Long> {
+
+    Optional<DailyQuiz> findByIdAndDeletedFalse(Long id);
+
+    Page<DailyQuiz> findAllByDeletedFalse(Pageable pageable);
+}


### PR DESCRIPTION
## 연관 이슈
  - 이 PR이 해결하는 이슈: #185
  - Epic: #184

## 작업 사항
- `feat(#185): 5분 상식 퀴즈 도메인 엔티티 및 리포지토리 추가`
- `feat(#185): 5분 상식 퀴즈 세트 등록 API 구현`
- `feat(#185): 5분 상식 퀴즈 세트 수정 및 발행 전환 API 구현`
    - 전달한 필드만 반영 (생략한 필드는 기존 값 유지)
- `feat(#185): 5분 상식 퀴즈 세트 목록 조회 API 구현`
- `feat(#185): 5분 상식 퀴즈 세트 상세 조회 API 구현`

## 테스트
- [X] 로컬 서버 테스트 완료

## 주의 사항 및 참고사항
- 

