### PR TITLE
feat(#186): 5분 상식 퀴즈 조회 API 구현

### DIFF
--- a/src/main/java/org/quizly/quizly/configuration/SecurityConfig.java
+++ b/src/main/java/org/quizly/quizly/configuration/SecurityConfig.java
@@ -71,6 +71,7 @@ public class SecurityConfig {
                 .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                 .requestMatchers(
                     "/faqs",
+                    "/daily-quizzes",
                     "/",
                     "/docs",
                     "/swagger-ui/**",

--- a/src/main/java/org/quizly/quizly/core/domain/repository/DailyQuizRepository.java
+++ b/src/main/java/org/quizly/quizly/core/domain/repository/DailyQuizRepository.java
@@ -1,14 +1,19 @@
 package org.quizly.quizly.core.domain.repository;
 
+import java.util.List;
 import java.util.Optional;
 import org.quizly.quizly.core.domain.entity.DailyQuiz;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface DailyQuizRepository extends JpaRepository<DailyQuiz, Long> {
 
     Optional<DailyQuiz> findByIdAndDeletedFalse(Long id);
 
     Page<DailyQuiz> findAllByDeletedFalse(Pageable pageable);
+    
+    @Query("SELECT d.id FROM DailyQuiz d WHERE d.published = true AND d.deleted = false")
+    List<Long> findAllPublishedIds();
 }

--- a/src/main/java/org/quizly/quizly/dailyquiz/controller/get/ReadDailyQuizController.java
+++ b/src/main/java/org/quizly/quizly/dailyquiz/controller/get/ReadDailyQuizController.java
@@ -1,0 +1,74 @@
+package org.quizly.quizly.dailyquiz.controller.get;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.quizly.quizly.configuration.swagger.ApiErrorCode;
+import org.quizly.quizly.core.application.BaseResponse;
+import org.quizly.quizly.core.domain.entity.DailyQuiz;
+import org.quizly.quizly.core.exception.error.GlobalErrorCode;
+import org.quizly.quizly.dailyquiz.dto.response.ReadDailyQuizResponse;
+import org.quizly.quizly.dailyquiz.dto.response.ReadDailyQuizResponse.QuestionDetail;
+import org.quizly.quizly.dailyquiz.service.ReadDailyQuizService;
+import org.quizly.quizly.dailyquiz.service.ReadDailyQuizService.ReadDailyQuizErrorCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "DailyQuiz", description = "5분 상식 퀴즈")
+public class ReadDailyQuizController {
+
+    private final ReadDailyQuizService readDailyQuizService;
+
+    @Operation(
+        summary = "5분 상식 퀴즈 조회 API",
+        description = "발행 중인 5분 상식 퀴즈 세트 중 하나를 무작위로 조회합니다.\n\n"
+            + "- OX 문항이 `questionNumber` 오름차순으로 3개 반환됩니다.\n"
+            + "- 정답(`answer`)과 해설(`explanation`)이 함께 내려가므로 프론트에서 즉시 채점할 수 있습니다.\n"
+            + "- `answer`는 TRUE 또는 FALSE입니다.\n"
+            + "- 발행 중인 세트가 하나도 없으면 404를 반환합니다.",
+        operationId = "/daily-quizzes"
+    )
+    @GetMapping("/daily-quizzes")
+    @ApiErrorCode(errorCodes = {GlobalErrorCode.class, ReadDailyQuizErrorCode.class})
+    public ResponseEntity<ReadDailyQuizResponse> readDailyQuiz() {
+        ReadDailyQuizService.ReadDailyQuizResponse serviceResponse = readDailyQuizService.execute(
+            ReadDailyQuizService.ReadDailyQuizRequest.builder().build()
+        );
+
+        if (serviceResponse == null || !serviceResponse.isSuccess()) {
+            Optional.ofNullable(serviceResponse)
+                .map(BaseResponse::getErrorCode)
+                .ifPresentOrElse(errorCode -> {
+                    throw errorCode.toException();
+                }, () -> {
+                    throw GlobalErrorCode.INTERNAL_ERROR.toException();
+                });
+        }
+
+        return ResponseEntity.ok(toResponse(serviceResponse));
+    }
+
+    private ReadDailyQuizResponse toResponse(
+        ReadDailyQuizService.ReadDailyQuizResponse serviceResponse) {
+        DailyQuiz dailyQuiz = serviceResponse.getDailyQuiz();
+
+        return ReadDailyQuizResponse.builder()
+            .dailyQuizId(dailyQuiz.getId())
+            .topic(dailyQuiz.getTopic())
+            .warmUp(dailyQuiz.getWarmUp())
+            .sourceContent(dailyQuiz.getSourceContent())
+            .questions(dailyQuiz.getQuestions().stream()
+                .map(question -> new QuestionDetail(
+                    question.getId(),
+                    question.getQuestionNumber(),
+                    question.getQuestionText(),
+                    question.getAnswer(),
+                    question.getExplanation()))
+                .toList())
+            .build();
+    }
+}

--- a/src/main/java/org/quizly/quizly/dailyquiz/dto/response/ReadDailyQuizResponse.java
+++ b/src/main/java/org/quizly/quizly/dailyquiz/dto/response/ReadDailyQuizResponse.java
@@ -1,0 +1,49 @@
+package org.quizly.quizly.dailyquiz.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.quizly.quizly.core.application.BaseResponse;
+import org.quizly.quizly.core.exception.error.GlobalErrorCode;
+
+@Getter
+@SuperBuilder
+@NoArgsConstructor
+@Schema(description = "5분 상식 퀴즈 조회 응답")
+public class ReadDailyQuizResponse extends BaseResponse<GlobalErrorCode> {
+
+    @Schema(description = "5분 상식 퀴즈 ID", example = "1")
+    private Long dailyQuizId;
+
+    @Schema(description = "주제", example = "환경")
+    private String topic;
+
+    @Schema(
+        description = "문제 워밍업",
+        example = "탄소중립의 핵심으로 떠오른 이 기체를 아시나요? 뉴스에서는 자주 접했지만 헷갈렸던 환경 상식, "
+            + "Quizly AI가 준비한 3문항의 미니 OX 퀴즈로 가볍게 점검해보세요!"
+    )
+    private String warmUp;
+
+    @Schema(
+        description = "AI가 읽은 원본 자료",
+        example = "메탄은 이산화탄소에 이어 두 번째로 큰 온실효과를 일으키는 기체로, ..."
+    )
+    private String sourceContent;
+
+    @Schema(description = "OX 문항 목록 (문항 번호 오름차순, 3개)")
+    private List<QuestionDetail> questions;
+
+    public record QuestionDetail(
+        @Schema(description = "문항 ID", example = "1") Long questionId,
+        @Schema(description = "문항 번호", example = "1") Integer questionNumber,
+        @Schema(description = "문항", example = "메탄은 이산화탄소보다 온실효과가 크다.") String questionText,
+        @Schema(description = "정답. TRUE 또는 FALSE", example = "TRUE") String answer,
+        @Schema(description = "해설", example = "메탄의 지구온난화지수는 이산화탄소의 약 28배입니다.")
+        String explanation
+    ) {
+
+    }
+}

--- a/src/main/java/org/quizly/quizly/dailyquiz/service/ReadDailyQuizService.java
+++ b/src/main/java/org/quizly/quizly/dailyquiz/service/ReadDailyQuizService.java
@@ -1,0 +1,89 @@
+package org.quizly.quizly.dailyquiz.service;
+
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.quizly.quizly.core.application.BaseRequest;
+import org.quizly.quizly.core.application.BaseResponse;
+import org.quizly.quizly.core.application.BaseService;
+import org.quizly.quizly.core.domain.entity.DailyQuiz;
+import org.quizly.quizly.core.domain.repository.DailyQuizRepository;
+import org.quizly.quizly.core.exception.DomainException;
+import org.quizly.quizly.core.exception.error.BaseErrorCode;
+import org.quizly.quizly.dailyquiz.service.ReadDailyQuizService.ReadDailyQuizRequest;
+import org.quizly.quizly.dailyquiz.service.ReadDailyQuizService.ReadDailyQuizResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ReadDailyQuizService implements
+    BaseService<ReadDailyQuizRequest, ReadDailyQuizResponse> {
+
+    private final DailyQuizRepository dailyQuizRepository;
+
+    @Override
+    public ReadDailyQuizResponse execute(ReadDailyQuizRequest request) {
+        List<Long> publishedIds = dailyQuizRepository.findAllPublishedIds();
+
+        if (publishedIds.isEmpty()) {
+            return fail();
+        }
+
+        Long selectedId = publishedIds.get(
+            ThreadLocalRandom.current().nextInt(publishedIds.size()));
+
+        DailyQuiz dailyQuiz = dailyQuizRepository.findByIdAndDeletedFalse(selectedId)
+            .orElse(null);
+
+        if (dailyQuiz == null) {
+            return fail();
+        }
+
+        dailyQuiz.getQuestions().size();
+
+        return ReadDailyQuizResponse.builder()
+            .dailyQuiz(dailyQuiz)
+            .build();
+    }
+
+    private ReadDailyQuizResponse fail() {
+        return ReadDailyQuizResponse.builder()
+            .success(false)
+            .errorCode(ReadDailyQuizErrorCode.NOT_FOUND_PUBLISHED_DAILY_QUIZ)
+            .build();
+    }
+
+    @Getter
+    @RequiredArgsConstructor
+    public enum ReadDailyQuizErrorCode implements BaseErrorCode<DomainException> {
+
+        NOT_FOUND_PUBLISHED_DAILY_QUIZ(HttpStatus.NOT_FOUND, "발행 중인 5분 상식 퀴즈가 없습니다.");
+
+        private final HttpStatus httpStatus;
+        private final String message;
+
+        @Override
+        public DomainException toException() {
+            return new DomainException(httpStatus, this);
+        }
+    }
+
+    @Getter
+    @Builder
+    public static class ReadDailyQuizRequest implements BaseRequest {
+
+    }
+
+    @Getter
+    @SuperBuilder
+    public static class ReadDailyQuizResponse extends BaseResponse<ReadDailyQuizErrorCode> {
+
+        private DailyQuiz dailyQuiz;
+    }
+}


### PR DESCRIPTION
## 연관 이슈
- 이 PR이 해결하는 이슈: #186
- Epic: #184
- 선행 PR: #185 (도메인 및 어드민 API)

## 작업 사항
- 5분 상식 퀴즈 조회 API 구현
    - 발행 중(`published = true`)인 세트 중 하나를 무작위로 반환

## 테스트
- [X] 로컬 서버 테스트 완료

## 주의 사항 및 참고사항
- 