### PR TITLE
feat(#190): FAQ 카테고리에 '모의고사 기능' 추가

### DIFF
--- a/src/main/java/org/quizly/quizly/admin/controller/post/CreateFaqController.java
+++ b/src/main/java/org/quizly/quizly/admin/controller/post/CreateFaqController.java
@@ -31,7 +31,7 @@ public class CreateFaqController {
     @Operation(
         summary = "FAQ 등록 API",
         description = "관리자 전용 API로 FAQ를 등록합니다.\n\n"
-            + "- 카테고리: SERVICE_INTRO(서비스 소개), QUIZ_GENERATION(문제 생성), WRONG_ANSWER(오답 관리), TECH_SUPPORT(기술 지원)",
+            + "- 카테고리: SERVICE_INTRO(서비스 소개), QUIZ_GENERATION(문제 생성), WRONG_ANSWER(오답 관리), MOCK_EXAM(모의고사 기능), TECH_SUPPORT(기술 지원)",
         operationId = "/admin/faqs"
     )
     @PostMapping("/admin/faqs")

--- a/src/main/java/org/quizly/quizly/core/domain/entity/Faq.java
+++ b/src/main/java/org/quizly/quizly/core/domain/entity/Faq.java
@@ -28,6 +28,7 @@ public class Faq extends BaseEntity {
         SERVICE_INTRO("서비스 소개"),
         QUIZ_GENERATION("문제 생성"),
         WRONG_ANSWER("오답 관리"),
+        MOCK_EXAM("모의고사 기능"),
         TECH_SUPPORT("기술 지원");
 
         private final String description;

--- a/src/main/java/org/quizly/quizly/faq/controller/get/ReadFaqController.java
+++ b/src/main/java/org/quizly/quizly/faq/controller/get/ReadFaqController.java
@@ -34,7 +34,7 @@ public class ReadFaqController {
         summary = "FAQ 조회 API",
         description = "FAQ 목록을 카테고리별로 조회합니다.\n\n"
             + "- `category` 미입력 시 전체 반환\n"
-            + "- 카테고리: SERVICE_INTRO(서비스 소개), QUIZ_GENERATION(문제 생성), WRONG_ANSWER(오답 관리), TECH_SUPPORT(기술 지원)",
+            + "- 카테고리: SERVICE_INTRO(서비스 소개), QUIZ_GENERATION(문제 생성), WRONG_ANSWER(오답 관리), MOCK_EXAM(모의고사 기능), TECH_SUPPORT(기술 지원)",
         operationId = "/faqs"
     )
     @GetMapping("/faqs")


### PR DESCRIPTION
## 연관 이슈
- 이 PR이 해결하는 이슈: #190

## 작업 사항
- FaqCategory에 MOCK_EXAM("모의고사 기능") 추가
- FAQ 등록/조회 API Swagger 설명 동기화

## 테스트
- [X] 로컬 서버 테스트 완료

## 주의 사항 및 참고사항
- Hibernate 6부터 MySQL에서 `@Enumerated(EnumType.STRING)`이 `VARCHAR`가 아닌 네이티브 `ENUM` 컬럼으로 매핑되어 `ddl-auto: update`만으로는 기존 `category` 컬럼의 ENUM 허용값 자동 갱신 X
    배포 전 하단 DDL을 실서버 DB에 수동으로 실행해야 함
    ```sql
    ALTER TABLE faq
        MODIFY COLUMN category ENUM('SERVICE_INTRO','QUIZ_GENERATION','WRONG_ANSWER','MOCK_EXAM','TECH_SUPPORT') NOT NULL;
