### PR TITLE
feat(#198): 회원 탈퇴(계정 삭제) API 구현

### DIFF
--- a/src/main/java/org/quizly/quizly/account/controller/delete/DeleteUserController.java
+++ b/src/main/java/org/quizly/quizly/account/controller/delete/DeleteUserController.java
@@ -1,0 +1,81 @@
+package org.quizly.quizly.account.controller.delete;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.quizly.quizly.account.service.DeleteUserService;
+import org.quizly.quizly.account.service.DeleteUserService.DeleteUserErrorCode;
+import org.quizly.quizly.account.service.DeleteUserService.DeleteUserRequest;
+import org.quizly.quizly.configuration.swagger.ApiErrorCode;
+import org.quizly.quizly.core.application.BaseResponse;
+import org.quizly.quizly.core.exception.error.GlobalErrorCode;
+import org.quizly.quizly.oauth.UserPrincipal;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "Account", description = "계정")
+public class DeleteUserController {
+
+    private final DeleteUserService deleteUserService;
+
+    @Operation(
+        summary = "회원 탈퇴 API",
+        description = "회원 전용 API로 현재 로그인 유저의 계정을 삭제 처리합니다.\n\n"
+            + "삭제 시 개인정보는 즉시 파기(익명화)되며 복구할 수 없습니다. "
+            + "동일한 소셜 계정으로 다시 로그인하면 신규 회원으로 가입됩니다.\n\n"
+            + "회원 API로 요청 시 토큰이 필요합니다. "
+            + "탈취된 accessToken만으로는 탈퇴가 불가능하도록, 로그인 시 발급된 refreshToken 쿠키가 "
+            + "서버에 저장된 값과 일치하는지 함께 검증합니다.",
+        operationId = "/account"
+    )
+    @DeleteMapping("/account")
+    @ApiErrorCode(errorCodes = {GlobalErrorCode.class, DeleteUserErrorCode.class})
+    public ResponseEntity<Void> deleteUser(
+        @AuthenticationPrincipal UserPrincipal userPrincipal,
+        @CookieValue("refreshToken") @Parameter(hidden = true) String refreshToken,
+        HttpServletResponse response
+    ) {
+
+        var serviceResponse = deleteUserService.execute(
+            DeleteUserRequest.builder()
+                .userPrincipal(userPrincipal)
+                .refreshToken(refreshToken)
+                .build());
+
+        if (!serviceResponse.isSuccess()) {
+            Optional.of(serviceResponse)
+                .map(BaseResponse::getErrorCode)
+                .ifPresentOrElse(errorCode -> {
+                    throw errorCode.toException();
+                }, () -> {
+                    throw GlobalErrorCode.INTERNAL_ERROR.toException();
+                });
+        }
+
+        log.info("[ACCOUNT] Delete - userId: {}", userPrincipal.getUserId());
+
+        ResponseCookie cookie = ResponseCookie.from("refreshToken", "")
+            .httpOnly(true)
+            .secure(true)
+            .path("/")
+            .sameSite("Strict")
+            .maxAge(0)
+            .build();
+
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/org/quizly/quizly/account/message/AccountDeleteNotificationMessage.java
+++ b/src/main/java/org/quizly/quizly/account/message/AccountDeleteNotificationMessage.java
@@ -1,0 +1,32 @@
+package org.quizly.quizly.account.message;
+
+import lombok.RequiredArgsConstructor;
+import org.quizly.quizly.core.domain.entity.User;
+import org.quizly.quizly.core.notification.NotificationChannel;
+import org.quizly.quizly.core.notification.NotificationMessage;
+
+@RequiredArgsConstructor
+public class AccountDeleteNotificationMessage implements NotificationMessage {
+
+    private final Long userId;
+    private final String nickName;
+    private final User.Provider provider;
+
+    @Override
+    public String title() {
+        return "회원 탈퇴";
+    }
+
+    @Override
+    public String body() {
+        return "유저가 탈퇴했습니다.\n"
+            + "userId: " + userId + "\n"
+            + "닉네임: " + nickName + "\n"
+            + "provider: " + provider;
+    }
+
+    @Override
+    public NotificationChannel channel() {
+        return NotificationChannel.SIGNUP;
+    }
+}

--- a/src/main/java/org/quizly/quizly/account/service/CreateOnboardingService.java
+++ b/src/main/java/org/quizly/quizly/account/service/CreateOnboardingService.java
@@ -1,6 +1,5 @@
 package org.quizly.quizly.account.service;
 
-import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,6 +10,8 @@ import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 import lombok.extern.log4j.Log4j2;
 import org.quizly.quizly.account.event.OnboardingCompletedEvent;
+import org.quizly.quizly.account.service.ReadUserService.ReadUserRequest;
+import org.quizly.quizly.account.service.ReadUserService.ReadUserResponse;
 import org.quizly.quizly.core.application.BaseRequest;
 import org.quizly.quizly.core.application.BaseResponse;
 import org.quizly.quizly.core.application.BaseService;
@@ -33,6 +34,7 @@ public class CreateOnboardingService
     CreateOnboardingService.CreateOnboardingRequest,
     CreateOnboardingService.CreateOnboardingResponse> {
 
+    private final ReadUserService readUserService;
     private final UserRepository userRepository;
     private final ApplicationEventPublisher eventPublisher;
 
@@ -45,24 +47,20 @@ public class CreateOnboardingService
                 .build();
         }
 
-        Long userId = request.getUserPrincipal().getUserId();
-        if (userId == null) {
-            return CreateOnboardingResponse.builder()
-                .success(false)
-                .errorCode(CreateOnboardingErrorCode.NOT_EXIST_PROVIDER_ID)
-                .build();
-        }
+        ReadUserResponse readUserResponse = readUserService.execute(
+            ReadUserRequest.builder()
+                .userPrincipal(request.getUserPrincipal())
+                .build()
+        );
 
-        Optional<User> userOptional = userRepository.findById(userId);
-        if (userOptional.isEmpty()) {
-            log.warn("[CreateOnboardingService] User not found for userId: {}", userId);
+        if (!readUserResponse.isSuccess()) {
             return CreateOnboardingResponse.builder()
                 .success(false)
                 .errorCode(CreateOnboardingErrorCode.NOT_FOUND_USER)
                 .build();
         }
 
-        User user = userOptional.get();
+        User user = readUserResponse.getUser();
 
         user.setTargetType(request.getTargetType());
         user.setStudyGoal(request.getStudyGoal());
@@ -78,7 +76,6 @@ public class CreateOnboardingService
     @RequiredArgsConstructor
     public enum CreateOnboardingErrorCode implements BaseErrorCode<DomainException> {
         NOT_EXIST_REQUIRED_PARAMETER(HttpStatus.BAD_REQUEST, "요청 파라미터가 존재하지 않습니다."),
-        NOT_EXIST_PROVIDER_ID(HttpStatus.BAD_REQUEST, "Provider ID가 존재하지 않습니다."),
         NOT_FOUND_USER(HttpStatus.NOT_FOUND, "유저를 찾을 수 없습니다.");
 
         private final HttpStatus httpStatus;

--- a/src/main/java/org/quizly/quizly/account/service/DeleteUserService.java
+++ b/src/main/java/org/quizly/quizly/account/service/DeleteUserService.java
@@ -13,13 +13,14 @@ import lombok.extern.log4j.Log4j2;
 import org.quizly.quizly.account.message.AccountDeleteNotificationMessage;
 import org.quizly.quizly.account.service.DeleteUserService.DeleteUserRequest;
 import org.quizly.quizly.account.service.DeleteUserService.DeleteUserResponse;
+import org.quizly.quizly.account.service.ReadUserService.ReadUserRequest;
+import org.quizly.quizly.account.service.ReadUserService.ReadUserResponse;
 import org.quizly.quizly.core.application.BaseRequest;
 import org.quizly.quizly.core.application.BaseResponse;
 import org.quizly.quizly.core.application.BaseService;
 import org.quizly.quizly.core.domain.entity.RefreshToken;
 import org.quizly.quizly.core.domain.entity.User;
 import org.quizly.quizly.core.domain.repository.RefreshTokenRepository;
-import org.quizly.quizly.core.domain.repository.UserRepository;
 import org.quizly.quizly.core.exception.DomainException;
 import org.quizly.quizly.core.exception.error.BaseErrorCode;
 import org.quizly.quizly.core.notification.NotificationProvider;
@@ -37,7 +38,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class DeleteUserService implements
     BaseService<DeleteUserRequest, DeleteUserResponse> {
 
-    private final UserRepository userRepository;
+    private final ReadUserService readUserService;
     private final RefreshTokenRepository refreshTokenRepository;
     private final NotificationProvider notificationProvider;
     private final JwtProvider jwtProvider;
@@ -51,13 +52,22 @@ public class DeleteUserService implements
                 .build();
         }
 
-        Long userId = request.getUserPrincipal().getUserId();
-        if (userId == null) {
+        ReadUserResponse readUserResponse = readUserService.execute(
+            ReadUserRequest.builder()
+                .userPrincipal(request.getUserPrincipal())
+                .build());
+
+        if (!readUserResponse.isSuccess()) {
+            log.warn("[DeleteUserService] User not found for userId: {}",
+                request.getUserPrincipal().getUserId());
             return DeleteUserResponse.builder()
                 .success(false)
-                .errorCode(DeleteUserErrorCode.NOT_EXIST_PROVIDER_ID)
+                .errorCode(DeleteUserErrorCode.NOT_FOUND_USER)
                 .build();
         }
+
+        User user = readUserResponse.getUser();
+        Long userId = user.getId();
 
         DeleteUserErrorCode refreshTokenErrorCode = validateRefreshToken(userId,
             request.getRefreshToken());
@@ -68,20 +78,9 @@ public class DeleteUserService implements
                 .build();
         }
 
-        return userRepository.findByIdAndDeletedFalse(userId)
-            .map(user -> {
-                deleteUser(user, userId);
-                DeleteUserResponse response = DeleteUserResponse.builder().build();
-                return response;
-            })
-            .orElseGet(() -> {
-                log.warn("[DeleteUserService] User not found for userId: {}", userId);
-                DeleteUserResponse response = DeleteUserResponse.builder()
-                    .success(false)
-                    .errorCode(DeleteUserErrorCode.NOT_FOUND_USER)
-                    .build();
-                return response;
-            });
+        deleteUser(user, userId);
+
+        return DeleteUserResponse.builder().build();
     }
 
     private DeleteUserErrorCode validateRefreshToken(Long userId, String refreshToken) {
@@ -132,7 +131,6 @@ public class DeleteUserService implements
     public enum DeleteUserErrorCode implements BaseErrorCode<DomainException> {
 
         NOT_EXIST_REQUIRED_PARAMETER(HttpStatus.BAD_REQUEST, "요청 파라미터가 존재하지 않습니다."),
-        NOT_EXIST_PROVIDER_ID(HttpStatus.BAD_REQUEST, "사용자 인증 정보가 제공되지 않았습니다."),
         NOT_FOUND_USER(HttpStatus.NOT_FOUND, "유저를 찾을 수 없습니다."),
         REFRESH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "리프레시 토큰이 만료되었습니다."),
         REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "리프레시 토큰을 찾을 수 없습니다."),

--- a/src/main/java/org/quizly/quizly/account/service/DeleteUserService.java
+++ b/src/main/java/org/quizly/quizly/account/service/DeleteUserService.java
@@ -10,6 +10,7 @@ import lombok.Setter;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 import lombok.extern.log4j.Log4j2;
+import org.quizly.quizly.account.message.AccountDeleteNotificationMessage;
 import org.quizly.quizly.account.service.DeleteUserService.DeleteUserRequest;
 import org.quizly.quizly.account.service.DeleteUserService.DeleteUserResponse;
 import org.quizly.quizly.core.application.BaseRequest;
@@ -21,6 +22,7 @@ import org.quizly.quizly.core.domain.repository.RefreshTokenRepository;
 import org.quizly.quizly.core.domain.repository.UserRepository;
 import org.quizly.quizly.core.exception.DomainException;
 import org.quizly.quizly.core.exception.error.BaseErrorCode;
+import org.quizly.quizly.core.notification.NotificationProvider;
 import org.quizly.quizly.jwt.JwtProvider;
 import org.quizly.quizly.jwt.error.AuthErrorCode;
 import org.quizly.quizly.oauth.UserPrincipal;
@@ -37,6 +39,7 @@ public class DeleteUserService implements
 
     private final UserRepository userRepository;
     private final RefreshTokenRepository refreshTokenRepository;
+    private final NotificationProvider notificationProvider;
     private final JwtProvider jwtProvider;
 
     @Override
@@ -109,9 +112,19 @@ public class DeleteUserService implements
     }
 
     private void deleteUser(User user, Long userId) {
+        String nickName = user.getNickName();
+        User.Provider provider = user.getProvider();
+
         user.softDelete();
         user.deletePersonalInfo();
         refreshTokenRepository.deleteByUserId(userId);
+
+        try {
+            notificationProvider.send(
+                new AccountDeleteNotificationMessage(userId, nickName, provider));
+        } catch (Exception e) {
+            log.warn("[DeleteUserService] 회원 탈퇴 슬랙 알림 전송 실패. userId: {}", userId, e);
+        }
     }
 
     @Getter

--- a/src/main/java/org/quizly/quizly/account/service/DeleteUserService.java
+++ b/src/main/java/org/quizly/quizly/account/service/DeleteUserService.java
@@ -1,0 +1,162 @@
+package org.quizly.quizly.account.service;
+
+import java.util.Optional;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+import lombok.extern.log4j.Log4j2;
+import org.quizly.quizly.account.service.DeleteUserService.DeleteUserRequest;
+import org.quizly.quizly.account.service.DeleteUserService.DeleteUserResponse;
+import org.quizly.quizly.core.application.BaseRequest;
+import org.quizly.quizly.core.application.BaseResponse;
+import org.quizly.quizly.core.application.BaseService;
+import org.quizly.quizly.core.domain.entity.RefreshToken;
+import org.quizly.quizly.core.domain.entity.User;
+import org.quizly.quizly.core.domain.repository.RefreshTokenRepository;
+import org.quizly.quizly.core.domain.repository.UserRepository;
+import org.quizly.quizly.core.exception.DomainException;
+import org.quizly.quizly.core.exception.error.BaseErrorCode;
+import org.quizly.quizly.jwt.JwtProvider;
+import org.quizly.quizly.jwt.error.AuthErrorCode;
+import org.quizly.quizly.oauth.UserPrincipal;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Log4j2
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class DeleteUserService implements
+    BaseService<DeleteUserRequest, DeleteUserResponse> {
+
+    private final UserRepository userRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final JwtProvider jwtProvider;
+
+    @Override
+    public DeleteUserResponse execute(DeleteUserRequest request) {
+        if (request == null || !request.isValid()) {
+            return DeleteUserResponse.builder()
+                .success(false)
+                .errorCode(DeleteUserErrorCode.NOT_EXIST_REQUIRED_PARAMETER)
+                .build();
+        }
+
+        Long userId = request.getUserPrincipal().getUserId();
+        if (userId == null) {
+            return DeleteUserResponse.builder()
+                .success(false)
+                .errorCode(DeleteUserErrorCode.NOT_EXIST_PROVIDER_ID)
+                .build();
+        }
+
+        DeleteUserErrorCode refreshTokenErrorCode = validateRefreshToken(userId,
+            request.getRefreshToken());
+        if (refreshTokenErrorCode != null) {
+            return DeleteUserResponse.builder()
+                .success(false)
+                .errorCode(refreshTokenErrorCode)
+                .build();
+        }
+
+        return userRepository.findByIdAndDeletedFalse(userId)
+            .map(user -> {
+                deleteUser(user, userId);
+                DeleteUserResponse response = DeleteUserResponse.builder().build();
+                return response;
+            })
+            .orElseGet(() -> {
+                log.warn("[DeleteUserService] User not found for userId: {}", userId);
+                DeleteUserResponse response = DeleteUserResponse.builder()
+                    .success(false)
+                    .errorCode(DeleteUserErrorCode.NOT_FOUND_USER)
+                    .build();
+                return response;
+            });
+    }
+
+    private DeleteUserErrorCode validateRefreshToken(Long userId, String refreshToken) {
+        AuthErrorCode tokenErrorCode = jwtProvider.validateToken(refreshToken);
+        if (tokenErrorCode != null) {
+            if (tokenErrorCode == AuthErrorCode.EXPIRED_ACCESS_TOKEN) {
+                return DeleteUserErrorCode.REFRESH_TOKEN_EXPIRED;
+            }
+            return DeleteUserErrorCode.REFRESH_TOKEN_INVALID;
+        }
+
+        if (!userId.equals(jwtProvider.getUserId(refreshToken))) {
+            log.warn("[DeleteUserService] AT/RT userId mismatch detected - userId: {}", userId);
+            return DeleteUserErrorCode.REFRESH_TOKEN_INVALID;
+        }
+
+        Optional<RefreshToken> refreshTokenOptional = refreshTokenRepository.findByUserId(userId);
+        if (refreshTokenOptional.isEmpty()) {
+            return DeleteUserErrorCode.REFRESH_TOKEN_NOT_FOUND;
+        }
+
+        if (!refreshTokenOptional.get().getToken().equals(refreshToken)) {
+            log.warn("[DeleteUserService] Refresh token mismatch detected - userId: {}", userId);
+            return DeleteUserErrorCode.REFRESH_TOKEN_INVALID;
+        }
+
+        return null;
+    }
+
+    private void deleteUser(User user, Long userId) {
+        user.softDelete();
+        user.deletePersonalInfo();
+        refreshTokenRepository.deleteByUserId(userId);
+    }
+
+    @Getter
+    @RequiredArgsConstructor
+    public enum DeleteUserErrorCode implements BaseErrorCode<DomainException> {
+
+        NOT_EXIST_REQUIRED_PARAMETER(HttpStatus.BAD_REQUEST, "요청 파라미터가 존재하지 않습니다."),
+        NOT_EXIST_PROVIDER_ID(HttpStatus.BAD_REQUEST, "사용자 인증 정보가 제공되지 않았습니다."),
+        NOT_FOUND_USER(HttpStatus.NOT_FOUND, "유저를 찾을 수 없습니다."),
+        REFRESH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "리프레시 토큰이 만료되었습니다."),
+        REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "리프레시 토큰을 찾을 수 없습니다."),
+        REFRESH_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "유효하지 않은 리프레시 토큰입니다.");
+
+        private final HttpStatus httpStatus;
+        private final String message;
+
+        @Override
+        public DomainException toException() {
+            return new DomainException(httpStatus, this);
+        }
+    }
+
+    @Getter
+    @Setter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @ToString
+    public static class DeleteUserRequest implements BaseRequest {
+
+        private UserPrincipal userPrincipal;
+        private String refreshToken;
+
+        @Override
+        public boolean isValid() {
+            return userPrincipal != null && refreshToken != null && !refreshToken.isEmpty();
+        }
+    }
+
+    @Getter
+    @Setter
+    @SuperBuilder
+    @NoArgsConstructor
+    @ToString
+    public static class DeleteUserResponse extends BaseResponse<DeleteUserErrorCode> {
+
+    }
+}

--- a/src/main/java/org/quizly/quizly/account/service/ReadUserService.java
+++ b/src/main/java/org/quizly/quizly/account/service/ReadUserService.java
@@ -48,7 +48,7 @@ public class ReadUserService implements
                 .build();
         }
 
-        Optional<User> userOptional = userRepository.findById(userId);
+        Optional<User> userOptional = userRepository.findByIdAndDeletedFalse(userId);
         if (userOptional.isEmpty()) {
             log.warn("[ReadUserService] User not found for userId: {}", userId);
             return ReadUserResponse.builder()

--- a/src/main/java/org/quizly/quizly/admin/service/BatchAggregateSummaryService.java
+++ b/src/main/java/org/quizly/quizly/admin/service/BatchAggregateSummaryService.java
@@ -6,13 +6,13 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.SuperBuilder;
 import lombok.extern.log4j.Log4j2;
+import org.quizly.quizly.account.service.ReadUserService;
 import org.quizly.quizly.admin.service.BatchAggregateSummaryService.BatchAggregateSummaryRequest;
 import org.quizly.quizly.admin.service.BatchAggregateSummaryService.BatchAggregateSummaryResponse;
 import org.quizly.quizly.core.application.BaseRequest;
 import org.quizly.quizly.core.application.BaseResponse;
 import org.quizly.quizly.core.application.BaseService;
 import org.quizly.quizly.core.domain.entity.User;
-import org.quizly.quizly.core.domain.repository.UserRepository;
 import org.quizly.quizly.core.exception.DomainException;
 import org.quizly.quizly.core.exception.error.BaseErrorCode;
 import org.quizly.quizly.oauth.UserPrincipal;
@@ -31,7 +31,7 @@ public class BatchAggregateSummaryService implements
 
     private final JobLauncher jobLauncher;
     private final Job aggregateDailySummaryJob;
-    private final UserRepository userRepository;
+    private final ReadUserService readUserService;
 
     @Override
     public BatchAggregateSummaryResponse execute(BatchAggregateSummaryRequest request) {
@@ -42,23 +42,21 @@ public class BatchAggregateSummaryService implements
                 .build();
         }
 
-        Long userId = request.getUserPrincipal().getUserId();
-        if (userId == null) {
-            return BatchAggregateSummaryResponse.builder()
-                .success(false)
-                .errorCode(BatchAggregateSummaryErrorCode.INVALID_PARAMETER)
-                .build();
-        }
+        ReadUserService.ReadUserResponse readUserResponse = readUserService.execute(
+            ReadUserService.ReadUserRequest.builder()
+                .userPrincipal(request.getUserPrincipal())
+                .build()
+        );
 
-        var userOptional = userRepository.findById(userId);
-        if (userOptional.isEmpty()) {
-            log.warn("[BatchAggregateSummaryService] User not found for userId: {}", userId);
+        if (!readUserResponse.isSuccess()) {
+            log.warn("[BatchAggregateSummaryService] User not found for userId: {}",
+                request.getUserPrincipal().getUserId());
             return BatchAggregateSummaryResponse.builder()
                 .success(false)
                 .errorCode(BatchAggregateSummaryErrorCode.NOT_FOUND_USER)
                 .build();
         }
-        User user = userOptional.get();
+        User user = readUserResponse.getUser();
 
         LocalDate targetDate = request.getTargetDate();
         LocalDate yesterday = LocalDate.now().minusDays(1);

--- a/src/main/java/org/quizly/quizly/core/domain/entity/User.java
+++ b/src/main/java/org/quizly/quizly/core/domain/entity/User.java
@@ -87,4 +87,17 @@ public class User extends BaseEntity {
             this.profileImageUrl = "https://kr.object.ncloudstorage.com/quizly-profile-images/defaults/default_profile.png";
         }
     }
+
+    public void softDelete() {
+        setDeleted(true);
+    }
+
+    public void deletePersonalInfo() {
+        this.email = "deleted-" + getId() + "@quizly.invalid";
+        this.name = "삭제된 사용자";
+        this.nickName = "삭제된 사용자";
+        this.profileImageUrl = null;
+        this.provider = null;
+        this.providerId = null;
+    }
 }

--- a/src/main/java/org/quizly/quizly/core/domain/repository/UserRepository.java
+++ b/src/main/java/org/quizly/quizly/core/domain/repository/UserRepository.java
@@ -7,4 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByProviderId(String providerId);
+
+    Optional<User> findByIdAndDeletedFalse(Long id);
 }

--- a/src/main/java/org/quizly/quizly/core/domain/repository/UserRepository.java
+++ b/src/main/java/org/quizly/quizly/core/domain/repository/UserRepository.java
@@ -9,4 +9,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByProviderId(String providerId);
 
     Optional<User> findByIdAndDeletedFalse(Long id);
+
+    long countByDeletedFalse();
 }

--- a/src/main/java/org/quizly/quizly/oauth/message/SignupNotificationMessage.java
+++ b/src/main/java/org/quizly/quizly/oauth/message/SignupNotificationMessage.java
@@ -22,7 +22,7 @@ public class SignupNotificationMessage implements NotificationMessage {
     @Override
     public String body() {
         return "새로운 유저가 가입했습니다!\n"
-            + "누적 가입자: " + totalMemberCount + "명\n"
+            + "총 가입자: " + totalMemberCount + "명\n"
             + "닉네임: " + user.getNickName() + "\n"
             + "가입 시각: " + user.getCreatedAt() + "\n"
             + "provider: " + user.getProvider();

--- a/src/main/java/org/quizly/quizly/oauth/service/RegisterOAuthUserService.java
+++ b/src/main/java/org/quizly/quizly/oauth/service/RegisterOAuthUserService.java
@@ -29,12 +29,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-/**
- * OAuth 사용자 정보를 받아온 이후의 DB 조회·생성·수정만 담당하는 서비스.
- *
- * <p>외부 OAuth 통신({@code super.loadUser})은 {@link OAuth2LoginUserService}에서 트랜잭션 밖으로 수행하고,
- * 이 서비스의 {@link #execute}만 트랜잭션으로 감싼다. 외부 응답 지연이 DB 커넥션 점유 시간에 영향을 주지 않도록 분리했다.
- */
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -82,7 +76,7 @@ public class RegisterOAuthUserService implements
         User savedUser = userRepository.save(userEntity);
 
         try {
-            long totalMemberCount = userRepository.count();
+            long totalMemberCount = userRepository.countByDeletedFalse();
             notificationProvider.send(new SignupNotificationMessage(savedUser, totalMemberCount))
                 .ifPresent(threadTs -> notificationThreadRepository.save(savedUser.getId(), threadTs));
         } catch (Exception e) {

--- a/src/main/java/org/quizly/quizly/oauth/service/ReissueAccessTokenService.java
+++ b/src/main/java/org/quizly/quizly/oauth/service/ReissueAccessTokenService.java
@@ -77,7 +77,7 @@ public class ReissueAccessTokenService implements
                 .build();
         }
 
-        Optional<User> userOptional = userRepository.findById(userId);
+        Optional<User> userOptional = userRepository.findByIdAndDeletedFalse(userId);
         if (userOptional.isEmpty()) {
             log.warn("[ReissueAccessTokenService] User Not  - userId: {}", userId);
             return ReissueAccessTokenResponse.builder()


### PR DESCRIPTION
## 연관 이슈
- 이 PR이 해결하는 이슈: #198

## 작업 사항
- `feat(#198): 회원 탈퇴 API 구현`
    - 삭제 후 동일 소셜 계정으로 재로그인 시 신규 회원으로 가입 처리 (기획 확인 완료)
    - 리프레시 토큰 검증 → 소프트 삭제 → 개인정보 익명화 → 리프레시 토큰 삭제
        - AT/RT userId 일치,만료 여부,DB에 저장된 토큰과의 일치 여부 확인 후 회원 탈퇴 진행
        - 탈취된 AT만으로는 계정 삭제 불가능 (단 RT는 유저당 1개만 저장되어 다른 기기에서 재로그인하면 이전 기기의 RT가 무효화되므로, 그 기기는 AT가 유효해도 탈퇴가 막힐 수 있음)
- `feat(#198): 회원 탈퇴 시 Slack 알림 연동`
    - 알림 전송 실패는 탈퇴 트랜잭션에 영향 없도록 예외 처리
- `refactor(#198): 탈퇴 회원 재조회 방지 및 User 조회 로직 통합`
    - User 조회 로직을 `ReadUserService`로 통합
    - 가입 알림의 누적 가입자 수를 `count()` → `countByDeletedFalse()`로 변경하여 탈퇴 회원이 집계에서 제외

## 테스트
- [X] 로컬 서버 테스트 완료 (Slack 알림 테스트 완료)

## 주의 사항 및 참고사항
- 
